### PR TITLE
Fix package naming typo

### DIFF
--- a/app/src/androidTest/java/com/github/onlynotesswent/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ExampleInstrumentedTest.kt
@@ -1,8 +1,8 @@
-package com.github.onlynoteswent
+package com.github.onlynotesswent
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.github.onlynoteswent.screen.SecondScreen
+import com.github.onlynotesswent.screen.MainScreen
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import org.junit.Rule
@@ -15,17 +15,17 @@ import org.junit.runner.RunWith
  * See [testing documentation](http://d.android.com/tools/testing).
  */
 @RunWith(AndroidJUnit4::class)
-class SecondActivityTest : TestCase() {
+class MainActivityTest : TestCase() {
 
-  @get:Rule val composeTestRule = createAndroidComposeRule<SecondActivity>()
+  @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()
 
   @Test
   fun test() = run {
-    step("Start Second Activity") {
-      ComposeScreen.onComposeScreen<SecondScreen>(composeTestRule) {
+    step("Start Main Activity") {
+      ComposeScreen.onComposeScreen<MainScreen>(composeTestRule) {
         simpleText {
           assertIsDisplayed()
-          assertTextEquals("Hello Robolectric!")
+          assertTextEquals("Hello Android!")
         }
       }
     }

--- a/app/src/androidTest/java/com/github/onlynotesswent/screen/MainScreen.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/screen/MainScreen.kt
@@ -1,7 +1,7 @@
-package com.github.onlynoteswent.screen
+package com.github.onlynotesswent.screen
 
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
-import com.github.onlynoteswent.resources.C
+import com.github.onlynotesswent.resources.C
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import io.github.kakaocup.compose.node.element.KNode
 

--- a/app/src/main/java/com/github/onlynotesswent/MainActivity.kt
+++ b/app/src/main/java/com/github/onlynotesswent/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.github.onlynoteswent
+package com.github.onlynotesswent
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -12,8 +12,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.tooling.preview.Preview
-import com.github.onlynoteswent.resources.C
-import com.github.onlynoteswent.ui.theme.SampleAppTheme
+import com.github.onlynotesswent.resources.C
+import com.github.onlynotesswent.ui.theme.SampleAppTheme
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/github/onlynotesswent/SecondActivity.kt
+++ b/app/src/main/java/com/github/onlynotesswent/SecondActivity.kt
@@ -1,4 +1,4 @@
-package com.github.onlynoteswent
+package com.github.onlynotesswent
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -12,8 +12,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.tooling.preview.Preview
-import com.github.onlynoteswent.resources.C
-import com.github.onlynoteswent.ui.theme.SampleAppTheme
+import com.github.onlynotesswent.resources.C
+import com.github.onlynotesswent.ui.theme.SampleAppTheme
 
 class SecondActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/github/onlynotesswent/SimpleData.kt
+++ b/app/src/main/java/com/github/onlynotesswent/SimpleData.kt
@@ -1,4 +1,4 @@
-package com.github.onlynoteswent
+package com.github.onlynotesswent
 
 import kotlin.math.sqrt
 

--- a/app/src/main/java/com/github/onlynotesswent/resources/C.kt
+++ b/app/src/main/java/com/github/onlynotesswent/resources/C.kt
@@ -1,4 +1,4 @@
-package com.github.onlynoteswent.resources
+package com.github.onlynotesswent.resources
 
 // Like R, but C
 object C {

--- a/app/src/main/java/com/github/onlynotesswent/ui/theme/Color.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/theme/Color.kt
@@ -1,4 +1,4 @@
-package com.github.onlynoteswent.ui.theme
+package com.github.onlynotesswent.ui.theme
 
 import androidx.compose.ui.graphics.Color
 

--- a/app/src/main/java/com/github/onlynotesswent/ui/theme/Theme.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/theme/Theme.kt
@@ -1,4 +1,4 @@
-package com.github.onlynoteswent.ui.theme
+package com.github.onlynotesswent.ui.theme
 
 import android.app.Activity
 import android.os.Build

--- a/app/src/main/java/com/github/onlynotesswent/ui/theme/Type.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/theme/Type.kt
@@ -1,4 +1,4 @@
-package com.github.onlynoteswent.ui.theme
+package com.github.onlynotesswent.ui.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle

--- a/app/src/test/java/com/github/onlynotesswent/ExampleRobolectricTest.kt
+++ b/app/src/test/java/com/github/onlynotesswent/ExampleRobolectricTest.kt
@@ -1,8 +1,8 @@
-package com.github.onlynoteswent
+package com.github.onlynotesswent
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.github.onlynoteswent.screen.MainScreen
+import com.github.onlynotesswent.screen.SecondScreen
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import org.junit.Rule
@@ -15,17 +15,17 @@ import org.junit.runner.RunWith
  * See [testing documentation](http://d.android.com/tools/testing).
  */
 @RunWith(AndroidJUnit4::class)
-class MainActivityTest : TestCase() {
+class SecondActivityTest : TestCase() {
 
-  @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()
+  @get:Rule val composeTestRule = createAndroidComposeRule<SecondActivity>()
 
   @Test
   fun test() = run {
-    step("Start Main Activity") {
-      ComposeScreen.onComposeScreen<MainScreen>(composeTestRule) {
+    step("Start Second Activity") {
+      ComposeScreen.onComposeScreen<SecondScreen>(composeTestRule) {
         simpleText {
           assertIsDisplayed()
-          assertTextEquals("Hello Android!")
+          assertTextEquals("Hello Robolectric!")
         }
       }
     }

--- a/app/src/test/java/com/github/onlynotesswent/ExampleUnitTest.kt
+++ b/app/src/test/java/com/github/onlynotesswent/ExampleUnitTest.kt
@@ -1,4 +1,4 @@
-package com.github.onlynoteswent
+package com.github.onlynotesswent
 
 import org.junit.Assert.*
 import org.junit.Test

--- a/app/src/test/java/com/github/onlynotesswent/PointTest.kt
+++ b/app/src/test/java/com/github/onlynotesswent/PointTest.kt
@@ -1,4 +1,4 @@
-package com.github.onlynoteswent
+package com.github.onlynotesswent
 
 import org.junit.Assert.assertEquals
 import org.junit.Test

--- a/app/src/test/java/com/github/onlynotesswent/screen/SecondScreen.kt
+++ b/app/src/test/java/com/github/onlynotesswent/screen/SecondScreen.kt
@@ -1,7 +1,7 @@
-package com.github.onlynoteswent.screen
+package com.github.onlynotesswent.screen
 
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
-import com.github.onlynoteswent.resources.C
+import com.github.onlynotesswent.resources.C
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import io.github.kakaocup.compose.node.element.KNode
 


### PR DESCRIPTION
Package was wrongfully named "com.github.onlynoteswent" instead of "com.github.onlynotesswent". I renamed packages and imports for main files, unit tests and android tests. Package name is now congruent with the one in build.gradle.kts and Firebase.