### PR TITLE
Rename app "OnlyNotes" (previously was "SampleApp")

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,6 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "SampleApp"
+rootProject.name = "OnlyNotes"
 include(":app")
  


### PR DESCRIPTION
Rename app correctly in _settings.gradle.kts_, which corrects the project name on android studio.