### PR TITLE
Bugfix/notes are not pushed to firebase

### DIFF
--- a/app/src/main/java/com/github/onlynotesswent/model/note/ImplementationNoteRepository.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/note/ImplementationNoteRepository.kt
@@ -22,7 +22,6 @@ class ImplementationNoteRepository(private val db: FirebaseFirestore) : NoteRepo
       val image: String
   )
 
-  // to convert a Note into a firebaseNote
   /**
    * Converts a note into a firebaseNote (a note that is compatible with firerbase).
    *

--- a/app/src/main/java/com/github/onlynotesswent/model/note/ImplementationNoteRepository.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/note/ImplementationNoteRepository.kt
@@ -4,11 +4,34 @@ import android.graphics.Bitmap
 import android.util.Log
 import com.google.android.gms.tasks.Task
 import com.google.firebase.Firebase
+import com.google.firebase.Timestamp
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 
 class ImplementationNoteRepository(private val db: FirebaseFirestore) : NoteRepository {
+
+
+  private data class firebaseNote(
+    val id: String,
+    val type: Type,
+    val name: String,
+    val title: String,
+    val content: String,
+    val date: Timestamp,
+    val userId: String,
+    val image: String
+  )
+
+  //to convert a Note into a firebaseNote
+  /**
+   * Converts a note into a firebaseNote (a note that is compatible with firerbase).
+   *
+   * @param note The note to convert.
+   * @return The converted firebaseNote object.
+   */
+  private fun convertNotes(note: Note): firebaseNote{
+    return firebaseNote(note.id, note.type, note.name, note.title, note.content, note.date, note.userId, "null") }
 
   private val collectionPath = "notes"
 
@@ -65,12 +88,12 @@ class ImplementationNoteRepository(private val db: FirebaseFirestore) : NoteRepo
 
   override fun insertNote(note: Note, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     performFirestoreOperation(
-        db.collection(collectionPath).document(note.id).set(note), onSuccess, onFailure)
+        db.collection(collectionPath).document(note.id).set(convertNotes(note)), onSuccess, onFailure)
   }
 
   override fun updateNote(note: Note, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     performFirestoreOperation(
-        db.collection(collectionPath).document(note.id).set(note), onSuccess, onFailure)
+        db.collection(collectionPath).document(note.id).set(convertNotes(note)), onSuccess, onFailure)
   }
 
   override fun deleteNoteById(id: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
@@ -117,7 +140,9 @@ class ImplementationNoteRepository(private val db: FirebaseFirestore) : NoteRepo
       val content = document.getString("content") ?: return null
       val date = document.getTimestamp("date") ?: return null
       val userId = document.getString("userId") ?: return null
-      val image = document.get("image") as? Bitmap ?: return null
+      val image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+      //Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888) is the default bitMap, to be changed when
+      // we implement images by URL
 
       Note(
           id = id,

--- a/app/src/main/java/com/github/onlynotesswent/model/note/ImplementationNoteRepository.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/note/ImplementationNoteRepository.kt
@@ -11,27 +11,28 @@ import com.google.firebase.firestore.FirebaseFirestore
 
 class ImplementationNoteRepository(private val db: FirebaseFirestore) : NoteRepository {
 
-
   private data class firebaseNote(
-    val id: String,
-    val type: Type,
-    val name: String,
-    val title: String,
-    val content: String,
-    val date: Timestamp,
-    val userId: String,
-    val image: String
+      val id: String,
+      val type: Type,
+      val name: String,
+      val title: String,
+      val content: String,
+      val date: Timestamp,
+      val userId: String,
+      val image: String
   )
 
-  //to convert a Note into a firebaseNote
+  // to convert a Note into a firebaseNote
   /**
    * Converts a note into a firebaseNote (a note that is compatible with firerbase).
    *
    * @param note The note to convert.
    * @return The converted firebaseNote object.
    */
-  private fun convertNotes(note: Note): firebaseNote{
-    return firebaseNote(note.id, note.type, note.name, note.title, note.content, note.date, note.userId, "null") }
+  private fun convertNotes(note: Note): firebaseNote {
+    return firebaseNote(
+        note.id, note.type, note.name, note.title, note.content, note.date, note.userId, "null")
+  }
 
   private val collectionPath = "notes"
 
@@ -88,12 +89,16 @@ class ImplementationNoteRepository(private val db: FirebaseFirestore) : NoteRepo
 
   override fun insertNote(note: Note, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     performFirestoreOperation(
-        db.collection(collectionPath).document(note.id).set(convertNotes(note)), onSuccess, onFailure)
+        db.collection(collectionPath).document(note.id).set(convertNotes(note)),
+        onSuccess,
+        onFailure)
   }
 
   override fun updateNote(note: Note, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     performFirestoreOperation(
-        db.collection(collectionPath).document(note.id).set(convertNotes(note)), onSuccess, onFailure)
+        db.collection(collectionPath).document(note.id).set(convertNotes(note)),
+        onSuccess,
+        onFailure)
   }
 
   override fun deleteNoteById(id: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
@@ -141,7 +146,8 @@ class ImplementationNoteRepository(private val db: FirebaseFirestore) : NoteRepo
       val date = document.getTimestamp("date") ?: return null
       val userId = document.getString("userId") ?: return null
       val image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
-      //Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888) is the default bitMap, to be changed when
+      // Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888) is the default bitMap, to be changed
+      // when
       // we implement images by URL
 
       Note(


### PR DESCRIPTION
Notes previously had a bitMap field that was unsupported by Firebase. A firebaseNote was therefore created that is compatible with Firebase set method and will have a String field instead of a bitMap that will contain an URL to an image. 