### PR TITLE
feature: add edit note screen

### DIFF
--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/editNote/EditNoteTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/editNote/EditNoteTest.kt
@@ -3,6 +3,7 @@ package com.github.onlynotesswent.ui.editNote
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import com.github.onlynotesswent.model.note.NoteRepository
 import com.github.onlynotesswent.model.note.NoteViewModel
 import com.github.onlynotesswent.model.users.UserRepository
@@ -14,6 +15,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 
 class EditNoteTest {
@@ -40,7 +42,15 @@ class EditNoteTest {
 
   @Test
   fun displayBaseComponents() {
-    composeTestRule.onNodeWithTag("EditNote text").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("GoBack button").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("EditNote textField").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("EditTitle textField").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("Save button").assertIsDisplayed()
+  }
+
+  @Test
+  fun saveClickCallsNavActions() {
+    composeTestRule.onNodeWithTag("Save button").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("Save button").performClick()
+    verify(navigationActions).navigateTo(screen = Screen.OVERVIEW)
   }
 }

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/editNote/EditNoteTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/editNote/EditNoteTest.kt
@@ -50,6 +50,6 @@ class EditNoteTest {
   @Test
   fun saveClickCallsNavActions() {
     composeTestRule.onNodeWithTag("Save button").performClick()
-    verify(navigationActions).navigateTo(screen = Screen.OVERVIEW)
+    verify(navigationActions).goBack()
   }
 }

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/editNote/EditNoteTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/editNote/EditNoteTest.kt
@@ -49,7 +49,6 @@ class EditNoteTest {
 
   @Test
   fun saveClickCallsNavActions() {
-    composeTestRule.onNodeWithTag("Save button").assertIsDisplayed()
     composeTestRule.onNodeWithTag("Save button").performClick()
     verify(navigationActions).navigateTo(screen = Screen.OVERVIEW)
   }

--- a/app/src/main/java/com/github/onlynotesswent/model/note/NoteViewModel.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/note/NoteViewModel.kt
@@ -14,7 +14,7 @@ class NoteViewModel(private val repository: NoteRepository) : ViewModel() {
   val notes: StateFlow<List<Note>> = notes_.asStateFlow()
 
   private val note_ = MutableStateFlow<Note?>(null)
-  val note: StateFlow<Note?> = note_.asStateFlow()
+  open val note: StateFlow<Note?> = note_.asStateFlow()
 
   init {
     repository
@@ -33,6 +33,9 @@ class NoteViewModel(private val repository: NoteRepository) : ViewModel() {
         }
   }
 
+  fun selectedNote(note: Note) {
+    note_.value = note
+  }
   /**
    * Generates a new unique ID.
    *

--- a/app/src/main/java/com/github/onlynotesswent/ui/screen/EditNote.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/screen/EditNote.kt
@@ -24,7 +24,6 @@ import com.github.onlynotesswent.model.note.Note
 import com.github.onlynotesswent.model.note.NoteViewModel
 import com.github.onlynotesswent.model.note.Type
 import com.github.onlynotesswent.ui.navigation.NavigationActions
-import com.github.onlynotesswent.ui.navigation.Screen
 import com.google.firebase.Timestamp
 
 /**

--- a/app/src/main/java/com/github/onlynotesswent/ui/screen/EditNote.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/screen/EditNote.kt
@@ -1,23 +1,89 @@
 package com.github.onlynotesswent.ui.screen
 
+import android.graphics.Bitmap
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.github.onlynotesswent.model.note.Note
 import com.github.onlynotesswent.model.note.NoteViewModel
+import com.github.onlynotesswent.model.note.Type
 import com.github.onlynotesswent.ui.navigation.NavigationActions
 import com.github.onlynotesswent.ui.navigation.Screen
+import com.google.firebase.Timestamp
 
+/**
+ * Displays the edit note screen, where users can update the title and content of an existing note.
+ * The screen includes two text fields for editing the note's title and content, and a button to
+ * save the changes. The save button updates the note in the ViewModel and navigates back to the
+ * overview screen.
+ *
+ * @param navigationActions The navigation view model used to transition between different screens.
+ * @param noteViewModel The ViewModel that provides the current note to be edited and handles note
+ *   updates.
+ */
 @Composable
 fun EditNoteScreen(navigationActions: NavigationActions, noteViewModel: NoteViewModel) {
-  Column {
-    Text("Edit Note Screen", modifier = Modifier.testTag("EditNote text"))
-    Button(
-        onClick = { navigationActions.navigateTo(Screen.AUTH) },
-        modifier = Modifier.testTag("GoBack button")) {
-          Text("Go to Auth")
-        }
-  }
+  val note by noteViewModel.note.collectAsState()
+  var updatedNoteText by remember { mutableStateOf(note?.content ?: "") } // Keep track of changes
+  var updatedNoteTitle by remember { mutableStateOf(note?.title ?: "") } // Keep track of changes
+
+  Column(
+      modifier = Modifier.fillMaxSize().padding(16.dp),
+      verticalArrangement = Arrangement.spacedBy(8.dp),
+      horizontalAlignment = Alignment.CenterHorizontally) {
+        Text("Edit Note Screen", modifier = Modifier.testTag("EditNote text"))
+
+        OutlinedTextField(
+            value = updatedNoteTitle,
+            onValueChange = { newTitle: String -> updatedNoteTitle = newTitle },
+            label = { Text("Note Title") },
+            placeholder = { Text("Enter the new title here") },
+            modifier = Modifier.fillMaxWidth().testTag("EditTitle textField"))
+
+        OutlinedTextField(
+            value = updatedNoteText,
+            onValueChange = { newText: String -> updatedNoteText = newText },
+            label = { Text("Note Content") },
+            placeholder = { Text("Enter your note here...") },
+            modifier = Modifier.fillMaxWidth().height(400.dp).testTag("EditNote textField"))
+
+        Button(
+            onClick = {
+              noteViewModel.updateNote(
+                  Note(
+                      id = note?.id ?: "1",
+                      type = Type.NORMAL_TEXT,
+                      name = note?.name ?: "error",
+                      title = updatedNoteTitle,
+                      content = updatedNoteText,
+                      date = Timestamp.now(), // Use current timestamp
+                      userId = note?.userId ?: "1",
+                      image =
+                          note?.image
+                              ?: Bitmap.createBitmap(
+                                  1, 1, Bitmap.Config.ARGB_8888) // Placeholder Bitmap
+                      ),
+                  "1")
+              navigationActions.navigateTo(Screen.OVERVIEW)
+            },
+            modifier = Modifier.testTag("Save button")) {
+              Text("Save")
+            }
+      }
 }

--- a/app/src/main/java/com/github/onlynotesswent/ui/screen/EditNote.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/screen/EditNote.kt
@@ -80,7 +80,7 @@ fun EditNoteScreen(navigationActions: NavigationActions, noteViewModel: NoteView
                                   1, 1, Bitmap.Config.ARGB_8888) // Placeholder Bitmap
                       ),
                   "1")
-              navigationActions.navigateTo(Screen.OVERVIEW)
+              navigationActions.goBack()
             },
             modifier = Modifier.testTag("Save button")) {
               Text("Save")

--- a/app/src/main/java/com/github/onlynotesswent/ui/screen/Overview.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/screen/Overview.kt
@@ -76,6 +76,7 @@ fun OverviewScreen(navigationActions: NavigationActions, noteViewModel: NoteView
                         .testTag("noteList")) {
                   items(notes.value.size) { index ->
                     NoteItem(note = notes.value[index]) {
+                      noteViewModel.selectedNote(notes.value[index])
                       navigationActions.navigateTo(Screen.EDIT_NOTE)
                     }
                   }
@@ -131,10 +132,14 @@ fun NoteItem(note: Note, onClick: () -> Unit) {
 
           Spacer(modifier = Modifier.height(4.dp))
           Text(
+              text = note.title,
+              style = MaterialTheme.typography.bodyMedium,
+              fontWeight = FontWeight.Bold)
+          Text(
               text = note.name,
               style = MaterialTheme.typography.bodyMedium,
               fontWeight = FontWeight.Bold)
-          Text(text = note.userId, style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+          Text(text = note.id, style = MaterialTheme.typography.bodySmall, color = Color.Gray)
         }
       }
 }


### PR DESCRIPTION
Introduced the EditNoteScreen, which allows users to edit the title and content of an existing note. The screen features two OutlinedTextField components, where users can update the note's title and content. A "Save" button updates the note in the repository and navigates back to the overview screen once the update is complete.

The screen uses the NoteViewModel to manage the state of the note being edited. The updated note is saved by invoking the updateNote method, which passes the updated note details to the repository. Due to the fact that user creation has not yet been integrated into the main branch, the user ID is currently hard-coded to "1". This will need to be adjusted once the user creation feature is implemented.

UI tests were also implemented for the added features.