### PR TITLE
fix: add SHA1 key to the APK Build

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -81,5 +81,5 @@ jobs:
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
-          name: app-debug.apk
-          path: app/build/outputs/apk/debug/app-debug.apk
+          name: app-release.apk
+          path: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -15,6 +15,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Create .android directory
+        run: |
+          mkdir -p ~/.android
+
       - name: Generate Debug Keystore
         run: |
           keytool -genkeypair -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Android Debug,O=Android,C=US"

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -40,13 +40,6 @@ jobs:
           accept-android-sdk-licenses: true
           cmdline-tools-version: "latest"  # Ensure you use the correct version if needed
 
-      # Decode the Keystore from secret and store it in the proper directory
-      - name: Decode Keystore
-        env:
-          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-        run: |
-          mkdir -p ~/.android
-          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > ~/.android/debug.keystore
 
       # Load google-services.json
       - name: Decode google-services.json
@@ -67,19 +60,17 @@ jobs:
           mkdir -p ~/.android
           echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > ~/.android/debug.keystore
 
-      # Build the APK with signing
+        # Generate SHA1 fingerprint from keystore
+      - name: Generate SHA1
+        run: keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android
+
+      # Build the debug APK
       - name: Build APK
-        run: |
-          ./gradlew assembleRelease \
-            -Pandroid.injected.signing.store.file=~/.android/debug.keystore \
-            -Pandroid.injected.signing.store.password=${{ secrets.KEYSTORE_PASSWORD }}
+        run: ./gradlew assembleDebug
 
-
-
-
-      # Upload the APK as an artifact
+      # Upload the debug APK as an artifact
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
-          name: app-release.apk
-          path: app/build/outputs/apk/release/app-release.apk
+          name: app-debug.apk
+          path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -3,8 +3,7 @@ name: Build APK
 on:
   push:
     branches:
-      - main
-      -  Fix/APK_BUILD
+      - Fix/APK_BUILD
   workflow_dispatch:
 
 jobs:
@@ -16,7 +15,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Set up JDK for Android build
+      # Set up JDK 11 for Android build
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
@@ -34,12 +33,31 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      # Set up Android SDK
+      # Download Android SDK components
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
         with:
           accept-android-sdk-licenses: true
-          cmdline-tools-version: "latest"
+          cmdline-tools-version: "latest"  # Ensure you use the correct version if needed
+
+      # Decode the Keystore from secret and store it in the proper directory
+      - name: Decode Keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          mkdir -p ~/.android
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > ~/.android/debug.keystore
+
+      # Load google-services.json
+      - name: Decode google-services.json
+        env:
+          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
+        run: |
+          echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
+
+       # Grant execute permission for the gradlew script
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
 
       # Decode the Keystore from secret
       - name: Decode Keystore
@@ -55,9 +73,11 @@ jobs:
           -Pandroid.injected.signing.store.password=${{ secrets.KEYSTORE_PASSWORD }} \
 
 
+
+
       # Upload the APK as an artifact
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
-          name: app-release.apk
-          path: app/build/outputs/apk/release/app-release.apk
+          name: app-debug.apk
+          path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,6 +1,9 @@
 name: Build APK
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -11,6 +14,10 @@ jobs:
       # Checkout the latest code
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Generate SHA-1 for debug keystore
+        run: |
+            keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android
 
       # Set up JDK 11 for Android build
       - name: Setup JDK

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -3,7 +3,6 @@ name: Build APK
 on:
   push:
     branches:
-      - main
       - Fix/APK_BUILD
   workflow_dispatch:
 
@@ -16,9 +15,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Generate Debug Keystore
+        run: |
+          keytool -genkeypair -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Android Debug,O=Android,C=US"
+
       - name: Generate SHA-1 for debug keystore
         run: |
-            keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android
+          keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android
 
       # Set up JDK 11 for Android build
       - name: Setup JDK

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -58,11 +58,11 @@ jobs:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
           mkdir -p ~/.android
-          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > ~/.android/debug.keystore
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > ~/.android/debug.jks
 
         # Generate SHA1 fingerprint from keystore
       - name: Generate SHA1
-        run: keytool -list -v -keystore ~/.android/debug.keystore -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEYSTORE_PASSWORD }}
+        run: keytool -list -v -keystore ~/.android/debug.jks -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEYSTORE_PASSWORD }}
       # Build the debug APK
       - name: Build APK
         run: ./gradlew assembleDebug
@@ -70,8 +70,8 @@ jobs:
       # Sign APK with custom keystore
       - name: Sign APK
         run: |
-          jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/.android/debug.keystore -storepass ${{ secrets.KEYSTORE_PASSWORD }} app/build/outputs/apk/debug/app-debug.apk
-
+        #  jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/.android/debug.keystore -storepass ${{ secrets.KEYSTORE_PASSWORD }} app/build/outputs/apk/debug/app-debug.apk
+         apksigner sign --ks ~/.android/debug.jks --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }}  app-debug.apk
 
 
       # Upload the debug APK as an artifact

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -67,12 +67,15 @@ jobs:
       - name: Build APK
         run: ./gradlew assembleDebug
 
+      #  jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/.android/debug.keystore -storepass ${{ secrets.KEYSTORE_PASSWORD }} app/build/outputs/apk/debug/app-debug.apk
+
       # Sign APK with custom keystore
       - name: Sign APK
         run: |
-        #  jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/.android/debug.keystore -storepass ${{ secrets.KEYSTORE_PASSWORD }} app/build/outputs/apk/debug/app-debug.apk
-          apksigner sign --ks ~/.android/debug.jks --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }}  app-debug.apk
-
+            apksigner sign \
+              --ks ~/.android/debug.jks \
+              --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }} \
+              app/build/outputs/apk/debug/app-debug.apk
 
       # Upload the debug APK as an artifact
       - name: Upload APK

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -62,8 +62,7 @@ jobs:
 
         # Generate SHA1 fingerprint from keystore
       - name: Generate SHA1
-        run: keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android
-
+        run: keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEYSTORE_PASSWORD }}
       # Build the debug APK
       - name: Build APK
         run: ./gradlew assembleDebug

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -98,6 +98,10 @@ jobs:
       - name: Verify APK Signature
         run: |
           ${ANDROID_HOME}/build-tools/${{ env.build_tools_version }}/apksigner verify app/build/outputs/apk/debug/app-debug.apk
+
+      # Verify APK Signature using SHA1
+      - name: Verify APK Signature using SHA1
+        run: keytool -printcert -jarfile app/build/outputs/apk/debug/app-debug.apk
           
 
 

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -67,6 +67,11 @@ jobs:
       - name: Build APK
         run: ./gradlew assembleDebug
 
+      # Sign APK with custom keystore
+      - name: Sign APK
+        run: |
+          jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/.android/my-release-key.keystore -storepass ${{ secrets.KEYSTORE_PASSWORD }} 
+
 
       # Upload the debug APK as an artifact
       - name: Upload APK

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -57,9 +57,10 @@ jobs:
           mkdir -p ~/.android
           echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > ~/.android/debug.keystore
 
-        # Generate SHA1 fingerprint from keystore
-      - name: Generate SHA1
+        # display the SHA1 of the keystore
+      - name: Print SHA1
         run: keytool -list -v -keystore ~/.android/debug.keystore -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEYSTORE_PASSWORD }}
+
       # Build the debug APK
       - name: Build APK
         run: ./gradlew assembleDebug
@@ -79,8 +80,8 @@ jobs:
         run: |
           ${ANDROID_HOME}/build-tools/${{ env.build_tools_version }}/apksigner verify app/build/outputs/apk/debug/app-debug.apk
 
-      # Verify APK Signature using SHA1
-      - name: Verify APK Signature using SHA1
+      # print the SHA1 of the APK
+      - name: Print the SHA1 of the APK
         run: keytool -printcert -jarfile app/build/outputs/apk/debug/app-debug.apk
           
 

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -84,7 +84,7 @@ jobs:
             -keystore  ~/.android/debug.keystore \
             -storepass ${{ secrets.KEYSTORE_PASSWORD }} \
             -keypass ${{ secrets.KEYSTORE_PASSWORD }} \
-            app/build/outputs/apk/release/app-debug.apk ${{ secrets.KEY_ALIAS }}
+            app/build/outputs/apk/debug/app-debug.apk ${{ secrets.KEY_ALIAS }}
 
 
       # Upload the debug APK as an artifact

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -39,8 +39,6 @@ jobs:
         with:
           accept-android-sdk-licenses: true
           cmdline-tools-version: "latest"  # Ensure you use the correct version if needed
-          components: |
-            build-tools;30.0.3  # Install Build Tools to access apksigner
 
 
       # Load google-services.json

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -84,20 +84,26 @@ jobs:
           #  -keypass ${{ secrets.KEYSTORE_PASSWORD }} \
 #            app/build/outputs/apk/debug/app-debug.apk ${{ secrets.KEY_ALIAS }}
 
-      - name: Sign APK
+      # Find the latest version of build-tools
+      - name: Find latest build-tools version
+        id: build_tools
+        run: echo "build_tools_version=$(ls ${ANDROID_HOME}/build-tools | sort -V | tail -n 1)" >> $GITHUB_ENV
+
+      # Sign the debug APK using apksigner
+      - name: Sign Debug APK with apksigner
         run: |
-          $ANDROID_HOME/build-tools/$ANDROID_BUILD_TOOLS_VERSION/apksigner sign \
-          --ks ~/.android/debug.keystore \
-          --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }} \
-          --key-pass pass:${{ secrets.KEYSTORE_PASSWORD }} \
-          --out app/build/outputs/apk/debug/app-debug-signed.apk \
-          app/build/outputs/apk/debug/app-debug.apk
+          ${ANDROID_HOME}/build-tools/${{ env.build_tools_version }}/apksigner sign --ks ~/.android/debug.keystore --ks-key-alias ${{ secrets.KEY_ALIAS }} --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }} --key-pass pass:${{ secrets.KEYSTORE_PASSWORD }} app/build/outputs/apk/debug/app-debug.apk
+
+      # Verify APK signature
+      - name: Verify APK Signature
+        run: |
+          ${ANDROID_HOME}/build-tools/${{ env.build_tools_version }}/apksigner verify app/build/outputs/apk/debug/app-debug.apk
           
 
       - name: Align APK
         run: |
           $ANDROID_HOME/build-tools/$ANDROID_BUILD_TOOLS_VERSION/zipalign -v 4 \
-          app/build/outputs/apk/debug/app-debug-signed.apk \
+          app/build/outputs/apk/debug/app-debug.apk \
           app/build/outputs/apk/debug/app-debug-aligned.apk   
 
 

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -69,8 +69,10 @@ jobs:
 
       # Build the APK with signing
       - name: Build APK
-        run: ./gradlew assembleRelease -Pandroid.injected.signing.store.file=~/.android/debug.keystore \
-          -Pandroid.injected.signing.store.password=${{ secrets.KEYSTORE_PASSWORD }} \
+        run: |
+          ./gradlew assembleRelease \
+            -Pandroid.injected.signing.store.file=~/.android/debug.keystore \
+            -Pandroid.injected.signing.store.password=${{ secrets.KEYSTORE_PASSWORD }}
 
 
 

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -76,13 +76,29 @@ jobs:
               #--ks ~/.android/debug.jks \
            #   --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }} \
             #  app/build/outputs/apk/debug/app-debug.apk
+     # - name: Sign APK
+       # run: |
+       #     jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 \
+         #   -keystore  ~/.android/debug.keystore \
+         #   -storepass ${{ secrets.KEYSTORE_PASSWORD }} \
+          #  -keypass ${{ secrets.KEYSTORE_PASSWORD }} \
+#            app/build/outputs/apk/debug/app-debug.apk ${{ secrets.KEY_ALIAS }}
+
       - name: Sign APK
         run: |
-            jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 \
-            -keystore  ~/.android/debug.keystore \
-            -storepass ${{ secrets.KEYSTORE_PASSWORD }} \
-            -keypass ${{ secrets.KEYSTORE_PASSWORD }} \
-            app/build/outputs/apk/debug/app-debug.apk ${{ secrets.KEY_ALIAS }}
+          $ANDROID_HOME/build-tools/$ANDROID_BUILD_TOOLS_VERSION/apksigner sign \
+          --ks ~/.android/debug.keystore \
+          --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }} \
+          --key-pass pass:${{ secrets.KEYSTORE_PASSWORD }} \
+          --out app/build/outputs/apk/debug/app-debug-signed.apk \
+          app/build/outputs/apk/debug/app-debug.apk
+          
+
+      - name: Align APK
+        run: |
+          $ANDROID_HOME/build-tools/$ANDROID_BUILD_TOOLS_VERSION/zipalign -v 4 \
+          app/build/outputs/apk/debug/app-debug-signed.apk \
+          app/build/outputs/apk/debug/app-debug-aligned.apk   
 
 
       # Upload the debug APK as an artifact
@@ -90,4 +106,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app-debug.apk
-          path: app/build/outputs/apk/debug/app-debug.apk
+          path: app/build/outputs/apk/debug/app-debug-aligned.apk

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - Fix/APK_BUILD
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -70,7 +70,7 @@ jobs:
       # Sign APK with custom keystore
       - name: Sign APK
         run: |
-          jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/.android/my-release-key.keystore -storepass ${{ secrets.KEYSTORE_PASSWORD }} 
+          jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/.android/debug.keystore -storepass ${{ secrets.KEYSTORE_PASSWORD }} 
 
 
       # Upload the debug APK as an artifact

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -100,16 +100,10 @@ jobs:
           ${ANDROID_HOME}/build-tools/${{ env.build_tools_version }}/apksigner verify app/build/outputs/apk/debug/app-debug.apk
           
 
-      - name: Align APK
-        run: |
-          $ANDROID_HOME/build-tools/$ANDROID_BUILD_TOOLS_VERSION/zipalign -v 4 \
-          app/build/outputs/apk/debug/app-debug.apk \
-          app/build/outputs/apk/debug/app-debug-aligned.apk   
-
 
       # Upload the debug APK as an artifact
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
           name: app-debug.apk
-          path: app/build/outputs/apk/debug/app-debug-aligned.apk
+          path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -60,11 +60,11 @@ jobs:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
           mkdir -p ~/.android
-          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > ~/.android/debug.jks
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > ~/.android/debug.keystore
 
         # Generate SHA1 fingerprint from keystore
       - name: Generate SHA1
-        run: keytool -list -v -keystore ~/.android/debug.jks -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEYSTORE_PASSWORD }}
+        run: keytool -list -v -keystore ~/.android/debug.keystore -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEYSTORE_PASSWORD }}
       # Build the debug APK
       - name: Build APK
         run: ./gradlew assembleDebug
@@ -72,12 +72,19 @@ jobs:
       #  jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/.android/debug.keystore -storepass ${{ secrets.KEYSTORE_PASSWORD }} app/build/outputs/apk/debug/app-debug.apk
 
       # Sign APK with custom keystore
+      #- name: Sign APK
+        #run: |
+            #apksigner sign \
+              #--ks ~/.android/debug.jks \
+           #   --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }} \
+            #  app/build/outputs/apk/debug/app-debug.apk
       - name: Sign APK
         run: |
-            apksigner sign \
-              --ks ~/.android/debug.jks \
-              --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }} \
-              app/build/outputs/apk/debug/app-debug.apk
+            jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 \
+            -keystore your-key-name.keystore \
+            -storepass ${{ secrets.KEYSTORE_PASSWORD }} \
+            app/build/outputs/apk/release/app-debug.apk ${{ secrets.KEY_ALIAS }}
+
 
       # Upload the debug APK as an artifact
       - name: Upload APK

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -39,6 +39,8 @@ jobs:
         with:
           accept-android-sdk-licenses: true
           cmdline-tools-version: "latest"  # Ensure you use the correct version if needed
+          components: |
+            build-tools;30.0.3  # Install Build Tools to access apksigner
 
 
       # Load google-services.json

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -3,7 +3,8 @@ name: Build APK
 on:
   push:
     branches:
-      - main  # Adjust as needed
+      - main
+      -  Fix/APK_BUILD
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Sign APK
         run: |
         #  jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/.android/debug.keystore -storepass ${{ secrets.KEYSTORE_PASSWORD }} app/build/outputs/apk/debug/app-debug.apk
-         apksigner sign --ks ~/.android/debug.jks --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }}  app-debug.apk
+          apksigner sign --ks ~/.android/debug.jks --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }}  app-debug.apk
 
 
       # Upload the debug APK as an artifact

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Build APK
         run: ./gradlew assembleDebug
 
+
       # Upload the debug APK as an artifact
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,9 +1,6 @@
 name: Build APK
 
 on:
-  push:
-    branches:
-      - Fix/APK_BUILD
   workflow_dispatch:
 
 jobs:
@@ -66,23 +63,6 @@ jobs:
       # Build the debug APK
       - name: Build APK
         run: ./gradlew assembleDebug
-
-      #  jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/.android/debug.keystore -storepass ${{ secrets.KEYSTORE_PASSWORD }} app/build/outputs/apk/debug/app-debug.apk
-
-      # Sign APK with custom keystore
-      #- name: Sign APK
-        #run: |
-            #apksigner sign \
-              #--ks ~/.android/debug.jks \
-           #   --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }} \
-            #  app/build/outputs/apk/debug/app-debug.apk
-     # - name: Sign APK
-       # run: |
-       #     jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 \
-         #   -keystore  ~/.android/debug.keystore \
-         #   -storepass ${{ secrets.KEYSTORE_PASSWORD }} \
-          #  -keypass ${{ secrets.KEYSTORE_PASSWORD }} \
-#            app/build/outputs/apk/debug/app-debug.apk ${{ secrets.KEY_ALIAS }}
 
       # Find the latest version of build-tools
       - name: Find latest build-tools version

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -81,8 +81,9 @@ jobs:
       - name: Sign APK
         run: |
             jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 \
-            -keystore your-key-name.keystore \
+            -keystore  ~/.android/debug.keystore \
             -storepass ${{ secrets.KEYSTORE_PASSWORD }} \
+            -keypass ${{ secrets.KEYSTORE_PASSWORD }} \
             app/build/outputs/apk/release/app-debug.apk ${{ secrets.KEY_ALIAS }}
 
 

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -70,7 +70,8 @@ jobs:
       # Sign APK with custom keystore
       - name: Sign APK
         run: |
-          jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/.android/debug.keystore -storepass ${{ secrets.KEYSTORE_PASSWORD }} 
+          jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/.android/debug.keystore -storepass ${{ secrets.KEYSTORE_PASSWORD }} app/build/outputs/apk/debug/app-debug.apk
+
 
 
       # Upload the debug APK as an artifact

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -3,7 +3,7 @@ name: Build APK
 on:
   push:
     branches:
-      - Fix/APK_BUILD
+      - main  # Adjust as needed
   workflow_dispatch:
 
 jobs:
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Set up JDK 11 for Android build
+      # Set up JDK for Android build
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
@@ -33,14 +33,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      # Download Android SDK components
+      # Set up Android SDK
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
         with:
           accept-android-sdk-licenses: true
-          cmdline-tools-version: "latest"  # Ensure you use the correct version if needed
+          cmdline-tools-version: "latest"
 
-      # Decode the Keystore from secret and store it in the proper directory
+      # Decode the Keystore from secret
       - name: Decode Keystore
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
@@ -48,26 +48,15 @@ jobs:
           mkdir -p ~/.android
           echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > ~/.android/debug.keystore
 
-      # Load google-services.json
-      - name: Decode google-services.json
-        env:
-          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
-        run: |
-          echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
-
-       # Grant execute permission for the gradlew script
-      - name: Grant execute permission for gradlew
-        run: chmod +x ./gradlew
-
-      # Build the APK
+      # Build the APK with signing
       - name: Build APK
-        run: ./gradlew assembleDebug
-
+        run: ./gradlew assembleRelease -Pandroid.injected.signing.store.file=~/.android/debug.keystore \
+          -Pandroid.injected.signing.store.password=${{ secrets.KEYSTORE_PASSWORD }} \
 
 
       # Upload the APK as an artifact
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
-          name: app-debug.apk
-          path: app/build/outputs/apk/debug/app-debug.apk
+          name: app-release.apk
+          path: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -15,18 +15,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Create .android directory
-        run: |
-          mkdir -p ~/.android
-
-      - name: Generate Debug Keystore
-        run: |
-          keytool -genkeypair -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Android Debug,O=Android,C=US"
-
-      - name: Generate SHA-1 for debug keystore
-        run: |
-          keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android
-
       # Set up JDK 11 for Android build
       - name: Setup JDK
         uses: actions/setup-java@v4
@@ -52,8 +40,16 @@ jobs:
           accept-android-sdk-licenses: true
           cmdline-tools-version: "latest"  # Ensure you use the correct version if needed
 
+      # Decode the Keystore from secret and store it in the proper directory
+      - name: Decode Keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          mkdir -p ~/.android
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > ~/.android/debug.keystore
+
       # Load google-services.json
-      - name: Decode secrets
+      - name: Decode google-services.json
         env:
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
         run: |

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -62,7 +62,7 @@ jobs:
 
         # Generate SHA1 fingerprint from keystore
       - name: Generate SHA1
-        run: keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEYSTORE_PASSWORD }}
+        run: keytool -list -v -keystore ~/.android/debug.keystore -storepass ${{ secrets.KEYSTORE_PASSWORD }} -keypass ${{ secrets.KEYSTORE_PASSWORD }}
       # Build the debug APK
       - name: Build APK
         run: ./gradlew assembleDebug


### PR DESCRIPTION
this modifcation make the APK-builder sign the APK with the keystore that have been added to github secrect