### PR TITLE
refactor: modify Note MVVM

### DIFF
--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/OverviewTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/OverviewTest.kt
@@ -34,10 +34,10 @@ class OverviewTest {
           Note(
               id = "1",
               type = Type.NORMAL_TEXT,
-              name = "Sample Note",
               title = "Sample Title",
               content = "This is a sample content.",
               date = Timestamp.now(), // Use current timestamp
+              public = true,
               userId = "1",
               image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888) // Placeholder Bitmap
               ))

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/OverviewTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/OverviewTest.kt
@@ -97,7 +97,6 @@ class OverviewTest {
     composeTestRule.onNodeWithTag("createNote").assertExists()
     composeTestRule.onNodeWithTag("emptyNotePrompt").assertExists()
     composeTestRule.onNodeWithTag("overviewScreen").assertExists()
-    composeTestRule.onNodeWithTag("RefreshButton").assertExists()
   }
 
   @Test

--- a/app/src/main/java/com/github/onlynotesswent/model/note/Note.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/note/Note.kt
@@ -6,10 +6,10 @@ import com.google.firebase.Timestamp
 data class Note(
     val id: String,
     val type: Type,
-    val name: String,
     val title: String,
     val content: String,
     val date: Timestamp,
+    val public: Boolean,
     val userId: String,
     val image: Bitmap
 )

--- a/app/src/main/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestore.kt
@@ -14,10 +14,10 @@ class NoteRepositoryFirestore(private val db: FirebaseFirestore) : NoteRepositor
   private data class FirebaseNote(
       val id: String,
       val type: Type,
-      val name: String,
       val title: String,
       val content: String,
       val date: Timestamp,
+      val public: Boolean,
       val userId: String,
       val image: String
   )
@@ -30,7 +30,7 @@ class NoteRepositoryFirestore(private val db: FirebaseFirestore) : NoteRepositor
    */
   private fun convertNotes(note: Note): FirebaseNote {
     return FirebaseNote(
-        note.id, note.type, note.name, note.title, note.content, note.date, note.userId, "null")
+        note.id, note.type, note.title, note.content, note.date, note.public, note.userId, "null")
   }
 
   private val collectionPath = "notes"
@@ -139,23 +139,22 @@ class NoteRepositoryFirestore(private val db: FirebaseFirestore) : NoteRepositor
     return try {
       val id = document.id
       val type = Type.valueOf(document.getString("type") ?: return null)
-      val name = document.getString("name") ?: return null
       val title = document.getString("title") ?: return null
       val content = document.getString("content") ?: return null
       val date = document.getTimestamp("date") ?: return null
+      val public = document.getBoolean("public") ?: true
       val userId = document.getString("userId") ?: return null
       val image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
       // Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888) is the default bitMap, to be changed
-      // when
-      // we implement images by URL
+      // when we implement images by URL
 
       Note(
           id = id,
           type = type,
-          name = name,
           title = title,
           content = content,
           date = date,
+          public = public,
           userId = userId,
           image = image)
     } catch (e: Exception) {

--- a/app/src/main/java/com/github/onlynotesswent/model/note/NoteViewModel.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/note/NoteViewModel.kt
@@ -17,9 +17,7 @@ class NoteViewModel(private val repository: NoteRepository) : ViewModel() {
   val note: StateFlow<Note?> = _note.asStateFlow()
 
   init {
-    repository
-        .init {} // I think we should fetch the user notes when he signs in, so calling getNotes()
-    // here. But I may be wrong (we can change this later on).
+    repository.init { getNotes("1") }
   }
 
   // create factory

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/AddNote.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/AddNote.kt
@@ -144,11 +144,11 @@ fun AddNoteScreen(
                         // provisional note, we will have to change this later
                         Note(
                             id = noteViewModel.getNewUid(),
-                            name = "name",
                             type = type,
                             title = title,
                             content = "",
                             date = Timestamp.now(),
+                            public = (visibility == "Public"),
                             userId = "1",
                             image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)),
                         "1")

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
@@ -68,10 +68,10 @@ fun EditNoteScreen(navigationActions: NavigationActions, noteViewModel: NoteView
                   Note(
                       id = note?.id ?: "1",
                       type = Type.NORMAL_TEXT,
-                      name = note?.name ?: "error",
                       title = updatedNoteTitle,
                       content = updatedNoteText,
                       date = Timestamp.now(), // Use current timestamp
+                      public = note?.public ?: true,
                       userId = note?.userId ?: "1",
                       image =
                           note?.image

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/Overview.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/Overview.kt
@@ -129,10 +129,6 @@ fun NoteItem(note: Note, onClick: () -> Unit) {
               text = note.title,
               style = MaterialTheme.typography.bodyMedium,
               fontWeight = FontWeight.Bold)
-          Text(
-              text = note.name,
-              style = MaterialTheme.typography.bodyMedium,
-              fontWeight = FontWeight.Bold)
           Text(text = note.id, style = MaterialTheme.typography.bodySmall, color = Color.Gray)
         }
       }

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/Overview.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/Overview.kt
@@ -65,7 +65,7 @@ fun OverviewScreen(navigationActions: NavigationActions, noteViewModel: NoteView
             tabList = LIST_TOP_LEVEL_DESTINATION,
             selectedItem = navigationActions.currentRoute())
       }) { pd ->
-        Box() {
+        Box {
           if (notes.value.isNotEmpty()) {
             LazyColumn(
                 contentPadding = PaddingValues(vertical = 40.dp),
@@ -86,12 +86,6 @@ fun OverviewScreen(navigationActions: NavigationActions, noteViewModel: NoteView
                 modifier = Modifier.padding(pd).testTag("emptyNotePrompt"),
                 text = "You have no Notes yet.")
           }
-          FloatingActionButton(
-              modifier =
-                  Modifier.align(Alignment.BottomCenter).padding(20.dp).testTag("RefreshButton"),
-              onClick = { noteViewModel.getNotes("1") }) {
-                Text("Refresh")
-              }
         }
       }
 }

--- a/app/src/test/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestoreTest.kt
@@ -39,10 +39,10 @@ class NoteRepositoryFirestoreTest {
       Note(
           id = "1",
           type = Type.NORMAL_TEXT,
-          name = "name",
           title = "title",
           content = "content",
           date = Timestamp.now(),
+          public = true,
           userId = "1",
           image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
 
@@ -74,10 +74,10 @@ class NoteRepositoryFirestoreTest {
 
     `when`(mockDocumentSnapshot.id).thenReturn("1")
     `when`(mockDocumentSnapshot.getString("type")).thenReturn(Type.NORMAL_TEXT.name)
-    `when`(mockDocumentSnapshot.getString("name")).thenReturn("name")
     `when`(mockDocumentSnapshot.getString("title")).thenReturn("title")
     `when`(mockDocumentSnapshot.getString("content")).thenReturn("content")
     `when`(mockDocumentSnapshot.getTimestamp("date")).thenReturn(currentTime)
+    `when`(mockDocumentSnapshot.getBoolean("public")).thenReturn(true)
     `when`(mockDocumentSnapshot.getString("userId")).thenReturn("1")
     val bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
     `when`(mockDocumentSnapshot.get("image")).thenReturn(bitmap)
@@ -87,10 +87,10 @@ class NoteRepositoryFirestoreTest {
     assertNotNull(note)
     assert(note?.id == "1")
     assert(note?.type == Type.NORMAL_TEXT)
-    assert(note?.name == "name")
     assert(note?.title == "title")
     assert(note?.content == "content")
     assert(note?.date == currentTime)
+    assert(note?.public == true)
     assert(note?.userId == "1")
     note?.image?.let { assert(it.sameAs(bitmap)) }
   }

--- a/app/src/test/java/com/github/onlynotesswent/model/note/NoteViewModelTest.kt
+++ b/app/src/test/java/com/github/onlynotesswent/model/note/NoteViewModelTest.kt
@@ -23,10 +23,10 @@ class NoteViewModelTest {
       Note(
           id = "1",
           type = Type.NORMAL_TEXT,
-          name = "name",
           title = "title",
           content = "content",
           date = Timestamp.now(),
+          public = true,
           userId = "1",
           image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
 


### PR DESCRIPTION
# Description

Refactoring the note MVVM architecture to improve code clarity and cleanliness. The following actions are performed:
1. `init` now calls `getNotes` in `NoteViewModel` file. The refresh floating button is no longer needed in the `Overview`.
2. unused val `name` is no longer used
3. boolean val `public` is added to save the state (public/private)

# How Has This Been Tested?

Tests are already in place.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- ~[ ] I have commented my code, particularly in hard-to-understand areas~  _// not needed_
- ~[ ] I have made corresponding changes to the documentation~  _// not needed_
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~  _// tests are already in place_
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged in downstream modules, no conflicts with main
