### PR TITLE
Bugfix: Note visibility rework – overview shows user notes and searchMenu public notes 

### DIFF
--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/EndToEndTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/EndToEndTest.kt
@@ -25,7 +25,6 @@ import androidx.test.espresso.intent.Intents
 import com.github.onlynotesswent.model.note.Note
 import com.github.onlynotesswent.model.note.NoteRepository
 import com.github.onlynotesswent.model.note.NoteViewModel
-import com.github.onlynotesswent.model.note.Type
 import com.github.onlynotesswent.model.scanner.Scanner
 import com.github.onlynotesswent.model.users.User
 import com.github.onlynotesswent.model.users.UserRepository
@@ -75,12 +74,12 @@ class EndToEndTest {
   private val testNote =
       Note(
           id = "1",
-          type = Type.NORMAL_TEXT,
+          type = Note.Type.NORMAL_TEXT,
           title = "title",
           content = "",
           date = Timestamp.now(),
           userId = testUid,
-          public = true,
+          visibility = Note.Visibility.DEFAULT,
           image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
 
   // Setup Compose test rule for UI testing
@@ -125,7 +124,7 @@ class EndToEndTest {
                     route = createUserRoute,
                 ) {
                   composable(Screen.CREATE_USER) {
-                    CreateUserScreen(navigationActions, noteViewModel, userViewModel)
+                    CreateUserScreen(navigationActions, userViewModel)
                   }
                 }
 
@@ -200,13 +199,13 @@ class EndToEndTest {
     composeTestRule.onNodeWithTag("createNoteButton").performClick()
 
     // Mock retrieval of notes
-    `when`(noteRepository.getNotes(eq(testUser.uid), any(), any())).thenAnswer { invocation ->
+    `when`(noteRepository.getNotesFrom(eq(testUser.uid), any(), any())).thenAnswer { invocation ->
       val onSuccess = invocation.getArgument<(List<Note>) -> Unit>(1)
       onSuccess(listOf(testNote))
     }
 
     // Trigger note retrieval and verify the notes are displayed
-    noteViewModel.getNotes(testUser.uid)
+    noteViewModel.getNotesFrom(testUser.uid)
     composeTestRule.onNodeWithTag("noteList").assertIsDisplayed()
 
     // Verify note details and navigate to the note editing screen

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/EndToEndTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/EndToEndTest.kt
@@ -79,7 +79,7 @@ class EndToEndTest {
           title = "title",
           content = "",
           date = Timestamp.now(),
-          userId = "1",
+          userId = testUid,
           public = true,
           image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
 
@@ -104,7 +104,7 @@ class EndToEndTest {
       onSuccess()
     }
 
-    `when`(noteRepository.getNewUid()).thenReturn("1")
+    `when`(noteRepository.getNewUid()).thenReturn(testNote.id)
 
     // Initialize Intents for handling navigation intents in the test
     Intents.init()
@@ -125,7 +125,7 @@ class EndToEndTest {
                     route = createUserRoute,
                 ) {
                   composable(Screen.CREATE_USER) {
-                    CreateUserScreen(navigationActions, userViewModel)
+                    CreateUserScreen(navigationActions, noteViewModel, userViewModel)
                   }
                 }
 
@@ -133,11 +133,15 @@ class EndToEndTest {
                     startDestination = Screen.OVERVIEW,
                     route = Route.OVERVIEW,
                 ) {
-                  composable(Screen.OVERVIEW) { OverviewScreen(navigationActions, noteViewModel) }
-                  composable(Screen.ADD_NOTE) {
-                    AddNoteScreen(navigationActions, scanner, noteViewModel)
+                  composable(Screen.OVERVIEW) {
+                    OverviewScreen(navigationActions, noteViewModel, userViewModel)
                   }
-                  composable(Screen.EDIT_NOTE) { EditNoteScreen(navigationActions, noteViewModel) }
+                  composable(Screen.ADD_NOTE) {
+                    AddNoteScreen(navigationActions, scanner, noteViewModel, userViewModel)
+                  }
+                  composable(Screen.EDIT_NOTE) {
+                    EditNoteScreen(navigationActions, noteViewModel, userViewModel)
+                  }
                 }
               }
         }
@@ -196,13 +200,13 @@ class EndToEndTest {
     composeTestRule.onNodeWithTag("createNoteButton").performClick()
 
     // Mock retrieval of notes
-    `when`(noteRepository.getNotes(eq("1"), any(), any())).thenAnswer { invocation ->
+    `when`(noteRepository.getNotes(eq(testUser.uid), any(), any())).thenAnswer { invocation ->
       val onSuccess = invocation.getArgument<(List<Note>) -> Unit>(1)
       onSuccess(listOf(testNote))
     }
 
     // Trigger note retrieval and verify the notes are displayed
-    noteViewModel.getNotes("1")
+    noteViewModel.getNotes(testUser.uid)
     composeTestRule.onNodeWithTag("noteList").assertIsDisplayed()
 
     // Verify note details and navigate to the note editing screen

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/AddNoteTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/AddNoteTest.kt
@@ -54,11 +54,11 @@ class AddNoteTest {
 
     // Mock the current route to be the add note screen
     `when`(mockNavigationActions.currentRoute()).thenReturn(Screen.ADD_NOTE)
-      // Mock the addUser method to call the onSuccess callback
-      `when`(mockUserRepository.addUser(any(), any(), any())).thenAnswer { invocation ->
-          val onSuccess = invocation.getArgument<() -> Unit>(1)
-          onSuccess()
-      }
+    // Mock the addUser method to call the onSuccess callback
+    `when`(mockUserRepository.addUser(any(), any(), any())).thenAnswer { invocation ->
+      val onSuccess = invocation.getArgument<() -> Unit>(1)
+      onSuccess()
+    }
   }
 
   @Test
@@ -204,7 +204,7 @@ class AddNoteTest {
     `when`(mockNoteRepository.getNewUid()).thenReturn("1")
     val testUser = User("", "", "username", "", "userID", Timestamp.now(), 0.0)
 
-    userViewModel.addUser(testUser,{},{})
+    userViewModel.addUser(testUser, {}, {})
 
     composeTestRule.onNodeWithTag("createNoteButton").performClick()
     verify(mockNoteRepository).addNote(any(), any<() -> Unit>(), any<(Exception) -> Unit>())

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/AddNoteTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/AddNoteTest.kt
@@ -17,25 +17,29 @@ import androidx.compose.ui.test.performTextInput
 import com.github.onlynotesswent.model.note.NoteRepository
 import com.github.onlynotesswent.model.note.NoteViewModel
 import com.github.onlynotesswent.model.scanner.Scanner
+import com.github.onlynotesswent.model.users.User
 import com.github.onlynotesswent.model.users.UserRepository
 import com.github.onlynotesswent.model.users.UserViewModel
 import com.github.onlynotesswent.ui.navigation.NavigationActions
 import com.github.onlynotesswent.ui.navigation.Screen
+import com.google.firebase.Timestamp
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 
 class AddNoteTest {
-  private lateinit var userRepository: UserRepository
+  @Mock private lateinit var mockUserRepository: UserRepository
   private lateinit var userViewModel: UserViewModel
-  private lateinit var navigationActions: NavigationActions
+  @Mock private lateinit var mockNavigationActions: NavigationActions
+  @Mock private lateinit var mockNoteRepository: NoteRepository
   private lateinit var noteViewModel: NoteViewModel
-  private lateinit var noteRepository: NoteRepository
   private lateinit var scanner: Scanner
 
   @get:Rule val composeTestRule = createComposeRule()
@@ -43,20 +47,20 @@ class AddNoteTest {
   @Before
   fun setUp() {
     // Mock is a way to create a fake object that can be used in place of a real object
-    userRepository = mock(UserRepository::class.java)
-    navigationActions = mock(NavigationActions::class.java)
-    userViewModel = UserViewModel(userRepository)
-    noteRepository = mock(NoteRepository::class.java)
-    noteViewModel = NoteViewModel(noteRepository)
+    MockitoAnnotations.openMocks(this)
+    userViewModel = UserViewModel(mockUserRepository)
+    noteViewModel = NoteViewModel(mockNoteRepository)
     scanner = Scanner(mock(ComponentActivity::class.java))
 
     // Mock the current route to be the add note screen
-    `when`(navigationActions.currentRoute()).thenReturn(Screen.ADD_NOTE)
+    `when`(mockNavigationActions.currentRoute()).thenReturn(Screen.ADD_NOTE)
   }
 
   @Test
   fun displayAllComponents() {
-    composeTestRule.setContent { AddNoteScreen(navigationActions, scanner, noteViewModel) }
+    composeTestRule.setContent {
+      AddNoteScreen(mockNavigationActions, scanner, noteViewModel, userViewModel)
+    }
 
     composeTestRule.onNodeWithTag("addNoteScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("addNoteTitle").assertIsDisplayed()
@@ -78,17 +82,21 @@ class AddNoteTest {
 
   @Test
   fun clickGoBackButton() {
-    composeTestRule.setContent { AddNoteScreen(navigationActions, scanner, noteViewModel) }
+    composeTestRule.setContent {
+      AddNoteScreen(mockNavigationActions, scanner, noteViewModel, userViewModel)
+    }
 
     composeTestRule.onNodeWithTag("goBackButton").performClick()
 
-    verify(navigationActions).goBack()
-    verify(navigationActions, never()).navigateTo(Screen.OVERVIEW)
+    verify(mockNavigationActions).goBack()
+    verify(mockNavigationActions, never()).navigateTo(Screen.OVERVIEW)
   }
 
   @Test
   fun doesNotSubmitWithoutTitleAndOptionsSelected() {
-    composeTestRule.setContent { AddNoteScreen(navigationActions, scanner, noteViewModel) }
+    composeTestRule.setContent {
+      AddNoteScreen(mockNavigationActions, scanner, noteViewModel, userViewModel)
+    }
 
     composeTestRule.onNodeWithTag("createNoteButton").assertIsNotEnabled()
 
@@ -117,7 +125,9 @@ class AddNoteTest {
 
   @Test
   fun createNoteButtonTextChangesWhenScanImageSelected() {
-    composeTestRule.setContent { AddNoteScreen(navigationActions, scanner, noteViewModel) }
+    composeTestRule.setContent {
+      AddNoteScreen(mockNavigationActions, scanner, noteViewModel, userViewModel)
+    }
 
     // Initially, the button text should be "Create Note"
     composeTestRule.onNodeWithTag("createNoteButton").assertTextEquals("Create Note")
@@ -137,7 +147,9 @@ class AddNoteTest {
 
   @Test
   fun createNoteButtonTextChangesWhenCreateFromScratchSelected() {
-    composeTestRule.setContent { AddNoteScreen(navigationActions, scanner, noteViewModel) }
+    composeTestRule.setContent {
+      AddNoteScreen(mockNavigationActions, scanner, noteViewModel, userViewModel)
+    }
 
     // Initially, the button text should be "Create Note"
     composeTestRule.onNodeWithTag("createNoteButton").assertTextEquals("Create Note")
@@ -157,7 +169,9 @@ class AddNoteTest {
 
   @Test
   fun createNoteFromScratchButtonCorrect() {
-    composeTestRule.setContent { AddNoteScreen(navigationActions, scanner, noteViewModel) }
+    composeTestRule.setContent {
+      AddNoteScreen(mockNavigationActions, scanner, noteViewModel, userViewModel)
+    }
 
     composeTestRule.onNodeWithTag("inputNoteTitle").performTextInput("test")
 
@@ -182,10 +196,13 @@ class AddNoteTest {
     // Now the button text should be "Create Note"
     composeTestRule.onNodeWithTag("createNoteButton").assertTextEquals("Create Note")
 
-    `when`(noteRepository.getNewUid()).thenReturn("1")
+    `when`(mockNoteRepository.getNewUid()).thenReturn("1")
+    val testUser = User("", "", "username", "", "userID", Timestamp.now(), 0.0)
+    userViewModel.setCurrentUser(testUser)
+
     composeTestRule.onNodeWithTag("createNoteButton").performClick()
-    verify(noteRepository).addNote(any(), any<() -> Unit>(), any<(Exception) -> Unit>())
-    verify(navigationActions).goBack()
-    verify(noteRepository).getNewUid()
+    verify(mockNoteRepository).addNote(any(), any<() -> Unit>(), any<(Exception) -> Unit>())
+    verify(mockNavigationActions).goBack()
+    verify(mockNoteRepository).getNewUid()
   }
 }

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/EditNoteTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/EditNoteTest.kt
@@ -6,10 +6,12 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.github.onlynotesswent.model.note.NoteRepository
 import com.github.onlynotesswent.model.note.NoteViewModel
+import com.github.onlynotesswent.model.users.User
 import com.github.onlynotesswent.model.users.UserRepository
 import com.github.onlynotesswent.model.users.UserViewModel
 import com.github.onlynotesswent.ui.navigation.NavigationActions
 import com.github.onlynotesswent.ui.navigation.Screen
+import com.google.firebase.Timestamp
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -34,9 +36,11 @@ class EditNoteTest {
     noteRepository = mock(NoteRepository::class.java)
     noteViewModel = NoteViewModel(noteRepository)
 
+    userViewModel.setCurrentUser(User("", "", "testUserName", "", "testUID", Timestamp.now(), 0.0))
+
     // Mock the current route to be the user create screen
     `when`(navigationActions.currentRoute()).thenReturn(Screen.EDIT_NOTE)
-    composeTestRule.setContent { EditNoteScreen(navigationActions, noteViewModel) }
+    composeTestRule.setContent { EditNoteScreen(navigationActions, noteViewModel, userViewModel) }
   }
 
   @Test
@@ -48,6 +52,7 @@ class EditNoteTest {
 
   @Test
   fun saveClickCallsNavActions() {
+
     composeTestRule.onNodeWithTag("Save button").performClick()
     verify(navigationActions).goBack()
   }

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/OverviewTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/OverviewTest.kt
@@ -93,8 +93,9 @@ class OverviewTest {
     }
     composeTestRule.onNodeWithTag("refreshButton").performClick()
 
-    // Verify that the repository was called twice, once during the initial load and once during the refresh click
-    verify(noteRepository,times(2)).getNotesFrom(eq("1"), any(), any())
+    // Verify that the repository was called twice, once during the initial load and once during the
+    // refresh click
+    verify(noteRepository, times(2)).getNotesFrom(eq("1"), any(), any())
     composeTestRule.onNodeWithTag("noteList").assertIsDisplayed()
   }
 

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/search/SearchTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/search/SearchTest.kt
@@ -24,30 +24,28 @@ class SearchScreenTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
-  private val testNote1 = Note(
-      id = "",
-      type = Note.Type.NORMAL_TEXT,
-      title = "Note 1",
-      content = "",
-      date = Timestamp.now(),
-      visibility = Note.Visibility.PUBLIC,
-      userId = "test",
-      image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
-    private val testNote2 = Note(
-        id = "1",
-        type = Note.Type.NORMAL_TEXT,
-        title = "Note 2",
-        content = "",
-        date = Timestamp.now(),
-        visibility = Note.Visibility.PUBLIC,
-        userId = "test",
-        image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
+  private val testNote1 =
+      Note(
+          id = "",
+          type = Note.Type.NORMAL_TEXT,
+          title = "Note 1",
+          content = "",
+          date = Timestamp.now(),
+          visibility = Note.Visibility.PUBLIC,
+          userId = "test",
+          image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
+  private val testNote2 =
+      Note(
+          id = "1",
+          type = Note.Type.NORMAL_TEXT,
+          title = "Note 2",
+          content = "",
+          date = Timestamp.now(),
+          visibility = Note.Visibility.PUBLIC,
+          userId = "test",
+          image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
 
-    private val mockNotes =
-      listOf(
-          testNote1,
-          testNote2
-      )
+  private val mockNotes = listOf(testNote1, testNote2)
 
   @Before
   fun setUp() {

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/search/SearchTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/search/SearchTest.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import com.github.onlynotesswent.model.note.Note
 import com.github.onlynotesswent.model.note.NoteRepository
 import com.github.onlynotesswent.model.note.NoteViewModel
-import com.github.onlynotesswent.model.note.Type
 import com.github.onlynotesswent.ui.navigation.NavigationActions
 import com.github.onlynotesswent.ui.navigation.Screen
 import com.google.firebase.Timestamp
@@ -25,26 +24,29 @@ class SearchScreenTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
-  private val mockNotes =
+  private val testNote1 = Note(
+      id = "",
+      type = Note.Type.NORMAL_TEXT,
+      title = "Note 1",
+      content = "",
+      date = Timestamp.now(),
+      visibility = Note.Visibility.PUBLIC,
+      userId = "test",
+      image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
+    private val testNote2 = Note(
+        id = "1",
+        type = Note.Type.NORMAL_TEXT,
+        title = "Note 2",
+        content = "",
+        date = Timestamp.now(),
+        visibility = Note.Visibility.PUBLIC,
+        userId = "test",
+        image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
+
+    private val mockNotes =
       listOf(
-          Note(
-              id = "",
-              type = Type.NORMAL_TEXT,
-              title = "Note 1",
-              content = "",
-              date = Timestamp.now(),
-              public = true,
-              userId = "test",
-              image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)),
-          Note(
-              id = "1",
-              type = Type.NORMAL_TEXT,
-              title = "Note 2",
-              content = "",
-              date = Timestamp.now(),
-              public = true,
-              userId = "test",
-              image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)),
+          testNote1,
+          testNote2
       )
 
   @Before
@@ -54,12 +56,12 @@ class SearchScreenTest {
     noteViewModel = NoteViewModel(noteRepository)
 
     `when`(navigationActions.currentRoute()).thenReturn(Screen.SEARCH_NOTE)
-    `when`(noteRepository.getNotes(any(), any(), any())).thenAnswer { invocation ->
-      val onSuccess = invocation.getArgument<(List<Note>) -> Unit>(1)
+    `when`(noteRepository.getPublicNotes(any(), any())).thenAnswer { invocation ->
+      val onSuccess = invocation.getArgument<(List<Note>) -> Unit>(0)
       onSuccess(mockNotes)
     }
 
-    noteViewModel.getNotes("test")
+    noteViewModel.getPublicNotes()
   }
 
   @Test
@@ -81,13 +83,13 @@ class SearchScreenTest {
   fun testValidSearchQueryShowsOneResult() {
     composeTestRule.setContent { SearchScreen(navigationActions, noteViewModel) }
 
-    composeTestRule.onNodeWithTag("searchTextField").performTextInput("Note 1")
+    composeTestRule.onNodeWithTag("searchTextField").performTextInput(testNote1.title)
 
     composeTestRule.onNodeWithTag("filteredNoteList").assertIsDisplayed()
     composeTestRule.onNodeWithTag("noSearchResults").assertIsNotDisplayed()
     composeTestRule
         .onAllNodesWithTag("noteCard")
-        .filter(hasText("Note 1"))
+        .filter(hasText(testNote1.title))
         .onFirst()
         .assertIsDisplayed()
     composeTestRule.onAllNodesWithTag("noteCard").assertCountEquals(1)
@@ -128,7 +130,7 @@ class SearchScreenTest {
   fun testNoteSelectionNavigatesToEditScreen() {
     composeTestRule.setContent { SearchScreen(navigationActions, noteViewModel) }
 
-    composeTestRule.onNodeWithTag("searchTextField").performTextInput("Note 1")
+    composeTestRule.onNodeWithTag("searchTextField").performTextInput(testNote1.title)
     composeTestRule.onNodeWithTag("filteredNoteList").onChildren().onFirst().performClick()
 
     verify(navigationActions).navigateTo(Screen.EDIT_NOTE)

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/user/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/user/ProfileScreenTest.kt
@@ -28,7 +28,6 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 
 class ProfileScreenTest {
   @Mock private lateinit var mockUserRepository: UserRepository
@@ -85,9 +84,7 @@ class ProfileScreenTest {
 
   @Test
   fun displayAllComponents() {
-    composeTestRule.setContent {
-      ProfileScreen(mockNavigationActions, userViewModel)
-    }
+    composeTestRule.setContent { ProfileScreen(mockNavigationActions, userViewModel) }
 
     composeTestRule.onNodeWithTag("ProfileScreen").assertExists()
     composeTestRule.onNodeWithTag("goBackButton").assertExists()
@@ -103,9 +100,7 @@ class ProfileScreenTest {
 
   @Test
   fun submitNavigatesToOverview() {
-    composeTestRule.setContent {
-      ProfileScreen(mockNavigationActions, userViewModel)
-    }
+    composeTestRule.setContent { ProfileScreen(mockNavigationActions, userViewModel) }
 
     composeTestRule.onNodeWithTag("saveButton").performClick()
     verify(mockNavigationActions).navigateTo(TopLevelDestinations.OVERVIEW)
@@ -113,9 +108,7 @@ class ProfileScreenTest {
 
   @Test
   fun modifyProfile() {
-    composeTestRule.setContent {
-      ProfileScreen(mockNavigationActions, userViewModel)
-    }
+    composeTestRule.setContent { ProfileScreen(mockNavigationActions, userViewModel) }
 
     composeTestRule.onNodeWithTag("inputUserName").performTextClearance()
     composeTestRule.onNodeWithTag("inputUserName").performTextInput("newUserName")

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/user/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/user/ProfileScreenTest.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import com.github.onlynotesswent.model.note.NoteRepository
+import com.github.onlynotesswent.model.note.NoteViewModel
 import com.github.onlynotesswent.model.users.User
 import com.github.onlynotesswent.model.users.UserRepository
 import com.github.onlynotesswent.model.users.UserRepositoryFirestore
@@ -22,10 +24,13 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 
 class ProfileScreenTest {
   @Mock private lateinit var mockUserRepository: UserRepository
   @Mock private lateinit var mockNavigationActions: NavigationActions
+  @Mock private lateinit var mockNoteRepository: NoteRepository
+  private lateinit var noteViewModel: NoteViewModel
   private lateinit var userViewModel: UserViewModel
   private val testUid = "testUid123"
   private val testUser =
@@ -47,6 +52,7 @@ class ProfileScreenTest {
     // Mock is a way to create a fake object that can be used in place of a real object
     MockitoAnnotations.openMocks(this)
     userViewModel = UserViewModel(mockUserRepository)
+    noteViewModel = NoteViewModel(mockNoteRepository)
 
     // Mock the current route to be the user create screen
     `when`(mockNavigationActions.currentRoute()).thenReturn(Screen.PROFILE)
@@ -69,7 +75,9 @@ class ProfileScreenTest {
 
   @Test
   fun displayAllComponents() {
-    composeTestRule.setContent { ProfileScreen(mockNavigationActions, userViewModel) }
+    composeTestRule.setContent {
+      ProfileScreen(mockNavigationActions, noteViewModel, userViewModel)
+    }
 
     composeTestRule.onNodeWithTag("ProfileScreen").assertExists()
     composeTestRule.onNodeWithTag("goBackButton").assertExists()
@@ -86,16 +94,21 @@ class ProfileScreenTest {
   // test that submit does navigate to the overview screen
   @Test
   fun submitNavigatesToOverview() {
-    composeTestRule.setContent { ProfileScreen(mockNavigationActions, userViewModel) }
+    composeTestRule.setContent {
+      ProfileScreen(mockNavigationActions, noteViewModel, userViewModel)
+    }
 
     composeTestRule.onNodeWithTag("saveButton").performClick()
     verify(mockNavigationActions).navigateTo(Screen.OVERVIEW)
+    verify(mockNoteRepository).getNotes(eq(testUser.uid), any(), any())
   }
 
   // test that modifying the profile works
   @Test
   fun modifyProfile() {
-    composeTestRule.setContent { ProfileScreen(mockNavigationActions, userViewModel) }
+    composeTestRule.setContent {
+      ProfileScreen(mockNavigationActions, noteViewModel, userViewModel)
+    }
 
     composeTestRule.onNodeWithTag("inputUserName").performTextClearance()
     composeTestRule.onNodeWithTag("inputUserName").performTextInput("newUserName")

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/user/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/user/ProfileScreenTest.kt
@@ -15,6 +15,7 @@ import com.github.onlynotesswent.model.users.UserRepositoryFirestore
 import com.github.onlynotesswent.model.users.UserViewModel
 import com.github.onlynotesswent.ui.navigation.NavigationActions
 import com.github.onlynotesswent.ui.navigation.Screen
+import com.github.onlynotesswent.ui.navigation.TopLevelDestinations
 import com.google.firebase.Timestamp
 import org.junit.Before
 import org.junit.Rule
@@ -76,7 +77,7 @@ class ProfileScreenTest {
   @Test
   fun displayAllComponents() {
     composeTestRule.setContent {
-      ProfileScreen(mockNavigationActions, noteViewModel, userViewModel)
+      ProfileScreen(mockNavigationActions, userViewModel)
     }
 
     composeTestRule.onNodeWithTag("ProfileScreen").assertExists()
@@ -95,19 +96,18 @@ class ProfileScreenTest {
   @Test
   fun submitNavigatesToOverview() {
     composeTestRule.setContent {
-      ProfileScreen(mockNavigationActions, noteViewModel, userViewModel)
+      ProfileScreen(mockNavigationActions, userViewModel)
     }
 
     composeTestRule.onNodeWithTag("saveButton").performClick()
-    verify(mockNavigationActions).navigateTo(Screen.OVERVIEW)
-    verify(mockNoteRepository).getNotes(eq(testUser.uid), any(), any())
+    verify(mockNavigationActions).navigateTo(TopLevelDestinations.OVERVIEW)
   }
 
   // test that modifying the profile works
   @Test
   fun modifyProfile() {
     composeTestRule.setContent {
-      ProfileScreen(mockNavigationActions, noteViewModel, userViewModel)
+      ProfileScreen(mockNavigationActions, userViewModel)
     }
 
     composeTestRule.onNodeWithTag("inputUserName").performTextClearance()

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/user/UserCreateScreenTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/user/UserCreateScreenTest.kt
@@ -16,6 +16,7 @@ import com.github.onlynotesswent.model.users.UserRepositoryFirestore
 import com.github.onlynotesswent.model.users.UserViewModel
 import com.github.onlynotesswent.ui.navigation.NavigationActions
 import com.github.onlynotesswent.ui.navigation.Screen
+import com.github.onlynotesswent.ui.navigation.TopLevelDestinations
 import com.google.firebase.Timestamp
 import org.junit.Before
 import org.junit.Rule
@@ -62,7 +63,7 @@ class UserCreateScreenTest {
   @Test
   fun displayAllComponents() {
     composeTestRule.setContent {
-      CreateUserScreen(mockNavigationActions, noteViewModel, userViewModel)
+      CreateUserScreen(mockNavigationActions, userViewModel)
     }
 
     composeTestRule.onNodeWithTag("loginLogo").assertIsDisplayed()
@@ -77,7 +78,7 @@ class UserCreateScreenTest {
   @Test
   fun doesNotSubmitWithoutUser() {
     composeTestRule.setContent {
-      CreateUserScreen(mockNavigationActions, noteViewModel, userViewModel)
+      CreateUserScreen(mockNavigationActions, userViewModel)
     }
 
     composeTestRule.onNodeWithTag("saveButton").performClick()
@@ -99,7 +100,7 @@ class UserCreateScreenTest {
     }
 
     composeTestRule.setContent {
-      CreateUserScreen(mockNavigationActions, noteViewModel, userViewModel)
+      CreateUserScreen(mockNavigationActions, userViewModel)
     }
 
     // Act: Enter the existing username and attempt to create a user
@@ -125,7 +126,7 @@ class UserCreateScreenTest {
     }
 
     composeTestRule.setContent {
-      CreateUserScreen(mockNavigationActions, noteViewModel, userViewModel)
+      CreateUserScreen(mockNavigationActions, userViewModel)
     }
 
     // Act: Enter the user data and create the user
@@ -140,7 +141,6 @@ class UserCreateScreenTest {
     composeTestRule.onNodeWithTag("saveButton").performClick()
 
     // Assert: Check that the navigation action was called
-    verify(mockNavigationActions).navigateTo(Screen.OVERVIEW)
-    verify(mockNoteRepository).getNotes(eq(testUser.uid), any(), any())
+    verify(mockNavigationActions).navigateTo(TopLevelDestinations.OVERVIEW)
   }
 }

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/user/UserCreateScreenTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/user/UserCreateScreenTest.kt
@@ -27,7 +27,6 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 
 class UserCreateScreenTest {
   @Mock private lateinit var mockUserRepository: UserRepository
@@ -62,9 +61,7 @@ class UserCreateScreenTest {
 
   @Test
   fun displayAllComponents() {
-    composeTestRule.setContent {
-      CreateUserScreen(mockNavigationActions, userViewModel)
-    }
+    composeTestRule.setContent { CreateUserScreen(mockNavigationActions, userViewModel) }
 
     composeTestRule.onNodeWithTag("loginLogo").assertIsDisplayed()
     composeTestRule.onNodeWithTag("addUserScreen").assertExists()
@@ -77,9 +74,7 @@ class UserCreateScreenTest {
 
   @Test
   fun doesNotSubmitWithoutUser() {
-    composeTestRule.setContent {
-      CreateUserScreen(mockNavigationActions, userViewModel)
-    }
+    composeTestRule.setContent { CreateUserScreen(mockNavigationActions, userViewModel) }
 
     composeTestRule.onNodeWithTag("saveButton").performClick()
     verify(mockUserRepository, never()).addUser(any(), any(), any())
@@ -99,9 +94,7 @@ class UserCreateScreenTest {
       onFailure(UserRepositoryFirestore.UsernameTakenException())
     }
 
-    composeTestRule.setContent {
-      CreateUserScreen(mockNavigationActions, userViewModel)
-    }
+    composeTestRule.setContent { CreateUserScreen(mockNavigationActions, userViewModel) }
 
     // Act: Enter the existing username and attempt to create a user
     composeTestRule.onNodeWithTag("inputUserName").performTextInput(existingUserName)
@@ -125,9 +118,7 @@ class UserCreateScreenTest {
       onSuccess()
     }
 
-    composeTestRule.setContent {
-      CreateUserScreen(mockNavigationActions, userViewModel)
-    }
+    composeTestRule.setContent { CreateUserScreen(mockNavigationActions, userViewModel) }
 
     // Act: Enter the user data and create the user
     composeTestRule.onNodeWithTag("inputFirstName").performTextInput(testUser.firstName)

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/user/UserCreateScreenTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/user/UserCreateScreenTest.kt
@@ -8,6 +8,8 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
+import com.github.onlynotesswent.model.note.NoteRepository
+import com.github.onlynotesswent.model.note.NoteViewModel
 import com.github.onlynotesswent.model.users.User
 import com.github.onlynotesswent.model.users.UserRepository
 import com.github.onlynotesswent.model.users.UserRepositoryFirestore
@@ -18,16 +20,20 @@ import com.google.firebase.Timestamp
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito.mock
+import org.mockito.Mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 
 class UserCreateScreenTest {
-  private lateinit var userRepository: UserRepository
+  @Mock private lateinit var mockUserRepository: UserRepository
+  @Mock private lateinit var mockNavigationActions: NavigationActions
+  @Mock private lateinit var mockNoteRepository: NoteRepository
   private lateinit var userViewModel: UserViewModel
-  private lateinit var navigationActions: NavigationActions
+  private lateinit var noteViewModel: NoteViewModel
   private val testUid = "testUid123"
   private val testUser =
       User(
@@ -45,17 +51,19 @@ class UserCreateScreenTest {
   @Before
   fun setUp() {
     // Mock is a way to create a fake object that can be used in place of a real object
-    userRepository = mock(UserRepository::class.java)
-    navigationActions = mock(NavigationActions::class.java)
-    userViewModel = UserViewModel(userRepository)
+    MockitoAnnotations.openMocks(this)
+    userViewModel = UserViewModel(mockUserRepository)
+    noteViewModel = NoteViewModel(mockNoteRepository)
 
     // Mock the current route to be the user create screen
-    `when`(navigationActions.currentRoute()).thenReturn(Screen.CREATE_USER)
+    `when`(mockNavigationActions.currentRoute()).thenReturn(Screen.CREATE_USER)
   }
 
   @Test
   fun displayAllComponents() {
-    composeTestRule.setContent { CreateUserScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent {
+      CreateUserScreen(mockNavigationActions, noteViewModel, userViewModel)
+    }
 
     composeTestRule.onNodeWithTag("loginLogo").assertIsDisplayed()
     composeTestRule.onNodeWithTag("addUserScreen").assertExists()
@@ -68,10 +76,12 @@ class UserCreateScreenTest {
 
   @Test
   fun doesNotSubmitWithoutUser() {
-    composeTestRule.setContent { CreateUserScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent {
+      CreateUserScreen(mockNavigationActions, noteViewModel, userViewModel)
+    }
 
     composeTestRule.onNodeWithTag("saveButton").performClick()
-    verify(userRepository, never()).addUser(any(), any(), any())
+    verify(mockUserRepository, never()).addUser(any(), any(), any())
   }
 
   private fun hasError(): SemanticsMatcher {
@@ -80,15 +90,17 @@ class UserCreateScreenTest {
 
   @Test
   fun doesNotSubmitAlreadyExistingUser() {
-    `when`(userViewModel.getNewUid()).thenReturn(testUid)
+    `when`(mockUserRepository.getNewUid()).thenReturn(testUid)
 
     // Mock the repository to return a result indicating the username already exists
-    `when`(userRepository.addUser(any(), any(), any())).thenAnswer { invocation ->
+    `when`(mockUserRepository.addUser(any(), any(), any())).thenAnswer { invocation ->
       val onFailure = invocation.getArgument<(Exception) -> Unit>(2)
       onFailure(UserRepositoryFirestore.UsernameTakenException())
     }
 
-    composeTestRule.setContent { CreateUserScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent {
+      CreateUserScreen(mockNavigationActions, noteViewModel, userViewModel)
+    }
 
     // Act: Enter the existing username and attempt to create a user
     composeTestRule.onNodeWithTag("inputUserName").performTextInput(existingUserName)
@@ -104,15 +116,17 @@ class UserCreateScreenTest {
   @Test
   fun goesToOverviewScreenOnSuccess() {
     // Mock the getNewUid method to return a consistent UID
-    `when`(userViewModel.getNewUid()).thenReturn(testUid)
+    `when`(mockUserRepository.getNewUid()).thenReturn(testUid)
 
     // Mock the addUser method to call the onSuccess callback
-    `when`(userRepository.addUser(any(), any(), any())).thenAnswer { invocation ->
+    `when`(mockUserRepository.addUser(any(), any(), any())).thenAnswer { invocation ->
       val onSuccess = invocation.getArgument<() -> Unit>(1)
       onSuccess()
     }
 
-    composeTestRule.setContent { CreateUserScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent {
+      CreateUserScreen(mockNavigationActions, noteViewModel, userViewModel)
+    }
 
     // Act: Enter the user data and create the user
     composeTestRule.onNodeWithTag("inputFirstName").performTextInput(testUser.firstName)
@@ -126,6 +140,7 @@ class UserCreateScreenTest {
     composeTestRule.onNodeWithTag("saveButton").performClick()
 
     // Assert: Check that the navigation action was called
-    verify(navigationActions).navigateTo(Screen.OVERVIEW)
+    verify(mockNavigationActions).navigateTo(Screen.OVERVIEW)
+    verify(mockNoteRepository).getNotes(eq(testUser.uid), any(), any())
   }
 }

--- a/app/src/main/java/com/github/onlynotesswent/MainActivity.kt
+++ b/app/src/main/java/com/github/onlynotesswent/MainActivity.kt
@@ -48,9 +48,7 @@ fun OnlyNotesApp(scanner: Scanner) {
         route = Route.AUTH,
     ) {
       composable(Screen.AUTH) { SignInScreen(navigationActions, userViewModel) }
-      composable(Screen.CREATE_USER) {
-        CreateUserScreen(navigationActions, noteViewModel, userViewModel)
-      }
+      composable(Screen.CREATE_USER) { CreateUserScreen(navigationActions, userViewModel) }
     }
 
     navigation(
@@ -79,7 +77,7 @@ fun OnlyNotesApp(scanner: Scanner) {
         startDestination = Screen.PROFILE,
         route = Route.PROFILE,
     ) {
-      composable(Screen.PROFILE) { ProfileScreen(navigationActions, noteViewModel, userViewModel) }
+      composable(Screen.PROFILE) { ProfileScreen(navigationActions, userViewModel) }
     }
   }
 }

--- a/app/src/main/java/com/github/onlynotesswent/MainActivity.kt
+++ b/app/src/main/java/com/github/onlynotesswent/MainActivity.kt
@@ -48,16 +48,24 @@ fun OnlyNotesApp(scanner: Scanner) {
         route = Route.AUTH,
     ) {
       composable(Screen.AUTH) { SignInScreen(navigationActions, userViewModel) }
-      composable(Screen.CREATE_USER) { CreateUserScreen(navigationActions, userViewModel) }
+      composable(Screen.CREATE_USER) {
+        CreateUserScreen(navigationActions, noteViewModel, userViewModel)
+      }
     }
 
     navigation(
         startDestination = Screen.OVERVIEW,
         route = Route.OVERVIEW,
     ) {
-      composable(Screen.OVERVIEW) { OverviewScreen(navigationActions, noteViewModel) }
-      composable(Screen.ADD_NOTE) { AddNoteScreen(navigationActions, scanner, noteViewModel) }
-      composable(Screen.EDIT_NOTE) { EditNoteScreen(navigationActions, noteViewModel) }
+      composable(Screen.OVERVIEW) {
+        OverviewScreen(navigationActions, noteViewModel, userViewModel)
+      }
+      composable(Screen.ADD_NOTE) {
+        AddNoteScreen(navigationActions, scanner, noteViewModel, userViewModel)
+      }
+      composable(Screen.EDIT_NOTE) {
+        EditNoteScreen(navigationActions, noteViewModel, userViewModel)
+      }
     }
 
     navigation(
@@ -71,7 +79,7 @@ fun OnlyNotesApp(scanner: Scanner) {
         startDestination = Screen.PROFILE,
         route = Route.PROFILE,
     ) {
-      composable(Screen.PROFILE) { ProfileScreen(navigationActions, userViewModel) }
+      composable(Screen.PROFILE) { ProfileScreen(navigationActions, noteViewModel, userViewModel) }
     }
   }
 }

--- a/app/src/main/java/com/github/onlynotesswent/model/note/Note.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/note/Note.kt
@@ -9,14 +9,44 @@ data class Note(
     val title: String,
     val content: String,
     val date: Timestamp,
-    val public: Boolean,
+    val visibility: Visibility,
     val userId: String,
     val image: Bitmap
-)
+) {
+  enum class Visibility {
+    PUBLIC,
+    FRIENDS,
+    PRIVATE;
 
-enum class Type {
-  JPEG,
-  PNG,
-  PDF,
-  NORMAL_TEXT
+    companion object {
+      val DEFAULT = PUBLIC
+      val READABLE_STRINGS = Visibility.values().map { it.toReadableString() }
+
+      fun fromReadableString(readableString: String): Visibility {
+        return values().find { it.toReadableString() == readableString }
+            ?: throw IllegalArgumentException("Invalid visibility string")
+      }
+
+      fun fromString(string: String): Visibility {
+        return values().find { it.toString() == string }
+            ?: throw IllegalArgumentException("Invalid visibility string")
+      }
+    }
+
+    fun toReadableString(): String {
+      return when (this) {
+        PUBLIC -> "Public"
+        FRIENDS -> "Friends Only"
+        PRIVATE -> "Private"
+        else -> "$this (not implemented)" // keep for maintainability
+      }
+    }
+  }
+
+  enum class Type {
+    JPEG,
+    PNG,
+    PDF,
+    NORMAL_TEXT
+  }
 }

--- a/app/src/main/java/com/github/onlynotesswent/model/note/NoteRepository.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/note/NoteRepository.kt
@@ -6,7 +6,9 @@ interface NoteRepository {
 
   fun init(onSuccess: () -> Unit)
 
-  fun getNotes(userId: String, onSuccess: (List<Note>) -> Unit, onFailure: (Exception) -> Unit)
+  fun getPublicNotes(onSuccess: (List<Note>) -> Unit, onFailure: (Exception) -> Unit)
+
+  fun getNotesFrom(userId: String, onSuccess: (List<Note>) -> Unit, onFailure: (Exception) -> Unit)
 
   fun getNoteById(id: String, onSuccess: (Note) -> Unit, onFailure: (Exception) -> Unit)
 

--- a/app/src/main/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestore.kt
@@ -13,11 +13,11 @@ class NoteRepositoryFirestore(private val db: FirebaseFirestore) : NoteRepositor
 
   private data class FirebaseNote(
       val id: String,
-      val type: Type,
+      val type: Note.Type,
       val title: String,
       val content: String,
       val date: Timestamp,
-      val public: Boolean,
+      val visibility: Note.Visibility,
       val userId: String,
       val image: String
   )
@@ -30,7 +30,14 @@ class NoteRepositoryFirestore(private val db: FirebaseFirestore) : NoteRepositor
    */
   private fun convertNotes(note: Note): FirebaseNote {
     return FirebaseNote(
-        note.id, note.type, note.title, note.content, note.date, note.public, note.userId, "null")
+        note.id,
+        note.type,
+        note.title,
+        note.content,
+        note.date,
+        note.visibility,
+        note.userId,
+        "null")
   }
 
   private val collectionPath = "notes"
@@ -47,7 +54,30 @@ class NoteRepositoryFirestore(private val db: FirebaseFirestore) : NoteRepositor
     }
   }
 
-  override fun getNotes(
+    /**
+     * Fetches all public notes from the Firestore database.
+     *
+     * @param onSuccess A callback function that is called with the list of public notes if the operation is successful.
+     * @param onFailure A callback function that is called with an exception if the operation fails.
+     */
+  override fun getPublicNotes(onSuccess: (List<Note>) -> Unit, onFailure: (Exception) -> Unit) {
+    db.collection(collectionPath).get().addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+        val publicNotes =
+            task.result.documents
+                .mapNotNull { document -> documentSnapshotToNote(document) }
+                .filter { it.visibility == Note.Visibility.PUBLIC } ?: emptyList()
+        onSuccess(publicNotes)
+      } else {
+        task.exception?.let { e ->
+          Log.e("NoteRepositoryFirestore", "Error getting visibility documents", e)
+          onFailure(e)
+        }
+      }
+    }
+  }
+
+  override fun getNotesFrom(
       userId: String,
       onSuccess: (List<Note>) -> Unit,
       onFailure: (Exception) -> Unit
@@ -55,9 +85,9 @@ class NoteRepositoryFirestore(private val db: FirebaseFirestore) : NoteRepositor
     db.collection(collectionPath).get().addOnCompleteListener { task ->
       if (task.isSuccessful) {
         val userNotes =
-            task.result
-                ?.mapNotNull { document -> documentSnapshotToNote(document) }
-                ?.filter { it.userId == userId } ?: emptyList()
+            task.result.documents
+                .mapNotNull { document -> documentSnapshotToNote(document) }
+                .filter { it.userId == userId } ?: emptyList()
         onSuccess(userNotes)
       } else {
         task.exception?.let { e ->
@@ -138,11 +168,13 @@ class NoteRepositoryFirestore(private val db: FirebaseFirestore) : NoteRepositor
   fun documentSnapshotToNote(document: DocumentSnapshot): Note? {
     return try {
       val id = document.id
-      val type = Type.valueOf(document.getString("type") ?: return null)
+      val type = Note.Type.valueOf(document.getString("type") ?: return null)
       val title = document.getString("title") ?: return null
       val content = document.getString("content") ?: return null
       val date = document.getTimestamp("date") ?: return null
-      val public = document.getBoolean("public") ?: true
+      val visibility =
+          Note.Visibility.fromString(
+              document.getString("visibility") ?: Note.Visibility.DEFAULT.toString())
       val userId = document.getString("userId") ?: return null
       val image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
       // Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888) is the default bitMap, to be changed
@@ -154,7 +186,7 @@ class NoteRepositoryFirestore(private val db: FirebaseFirestore) : NoteRepositor
           title = title,
           content = content,
           date = date,
-          public = public,
+          visibility = visibility,
           userId = userId,
           image = image)
     } catch (e: Exception) {

--- a/app/src/main/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestore.kt
@@ -54,15 +54,16 @@ class NoteRepositoryFirestore(private val db: FirebaseFirestore) : NoteRepositor
     }
   }
 
-    /**
-     * Fetches all public notes from the Firestore database.
-     *
-     * @param onSuccess A callback function that is called with the list of public notes if the operation is successful.
-     * @param onFailure A callback function that is called with an exception if the operation fails.
-     */
+  /**
+   * Fetches all public notes from the Firestore database.
+   *
+   * @param onSuccess A callback function that is called with the list of public notes if the
+   *   operation is successful.
+   * @param onFailure A callback function that is called with an exception if the operation fails.
+   */
   override fun getPublicNotes(onSuccess: (List<Note>) -> Unit, onFailure: (Exception) -> Unit) {
     db.collection(collectionPath).get().addOnCompleteListener { task ->
-        if (task.isSuccessful) {
+      if (task.isSuccessful) {
         val publicNotes =
             task.result.documents
                 .mapNotNull { document -> documentSnapshotToNote(document) }

--- a/app/src/main/java/com/github/onlynotesswent/model/note/NoteViewModel.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/note/NoteViewModel.kt
@@ -10,14 +10,17 @@ import kotlinx.coroutines.flow.asStateFlow
 
 class NoteViewModel(private val repository: NoteRepository) : ViewModel() {
 
-  private val _notes = MutableStateFlow<List<Note>>(emptyList())
-  val notes: StateFlow<List<Note>> = _notes.asStateFlow()
+  private val _publicNotes = MutableStateFlow<List<Note>>(emptyList())
+  val publicNotes: StateFlow<List<Note>> = _publicNotes.asStateFlow()
 
-  private val _note = MutableStateFlow<Note?>(null)
-  val note: StateFlow<Note?> = _note.asStateFlow()
+  private val _userNotes = MutableStateFlow<List<Note>>(emptyList())
+  val userNotes: StateFlow<List<Note>> = _userNotes.asStateFlow()
+
+  private val _selectedNote = MutableStateFlow<Note?>(null)
+  val selectedNote: StateFlow<Note?> = _selectedNote.asStateFlow()
 
   init {
-    repository.init { getNotes("1") }
+    repository.init { getPublicNotes() }
   }
 
   // create factory
@@ -31,8 +34,8 @@ class NoteViewModel(private val repository: NoteRepository) : ViewModel() {
         }
   }
 
-  fun selectedNote(note: Note) {
-    _note.value = note
+  fun selectedNote(selectedNote: Note) {
+    _selectedNote.value = selectedNote
   }
   /**
    * Generates a new unique ID.
@@ -43,9 +46,14 @@ class NoteViewModel(private val repository: NoteRepository) : ViewModel() {
     return repository.getNewUid()
   }
 
-  /** Gets all Note documents. */
-  fun getNotes(userID: String) {
-    repository.getNotes(userID, onSuccess = { _notes.value = it }, onFailure = {})
+  /** Gets all public Note documents. */
+  fun getPublicNotes() {
+    repository.getPublicNotes(onSuccess = { _publicNotes.value = it }, onFailure = {})
+  }
+
+  /** Gets all Note documents from a user, specified by their ID. */
+  fun getNotesFrom(userID: String) {
+    repository.getNotesFrom(userID, onSuccess = { _userNotes.value = it }, onFailure = {})
   }
 
   /**
@@ -54,7 +62,7 @@ class NoteViewModel(private val repository: NoteRepository) : ViewModel() {
    * @param noteId The ID of the Note document to be fetched.
    */
   fun getNoteById(noteId: String) {
-    repository.getNoteById(id = noteId, onSuccess = { _note.value = it }, onFailure = {})
+    repository.getNoteById(id = noteId, onSuccess = { _selectedNote.value = it }, onFailure = {})
   }
 
   /**
@@ -64,7 +72,7 @@ class NoteViewModel(private val repository: NoteRepository) : ViewModel() {
    * @param userID The user ID.
    */
   fun addNote(note: Note, userID: String) {
-    repository.addNote(note = note, onSuccess = { getNotes(userID) }, onFailure = {})
+    repository.addNote(note = note, onSuccess = { getNotesFrom(userID) }, onFailure = {})
   }
 
   /**
@@ -74,7 +82,7 @@ class NoteViewModel(private val repository: NoteRepository) : ViewModel() {
    * @param userID The user ID.
    */
   fun updateNote(note: Note, userID: String) {
-    repository.updateNote(note = note, onSuccess = { getNotes(userID) }, onFailure = {})
+    repository.updateNote(note = note, onSuccess = { getNotesFrom(userID) }, onFailure = {})
   }
 
   /**
@@ -84,6 +92,6 @@ class NoteViewModel(private val repository: NoteRepository) : ViewModel() {
    * @param userID The user ID.
    */
   fun deleteNoteById(noteId: String, userID: String) {
-    repository.deleteNoteById(id = noteId, onSuccess = { getNotes(userID) }, onFailure = {})
+    repository.deleteNoteById(id = noteId, onSuccess = { getNotesFrom(userID) }, onFailure = {})
   }
 }

--- a/app/src/main/java/com/github/onlynotesswent/model/users/UserViewModel.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/users/UserViewModel.kt
@@ -2,6 +2,8 @@ package com.github.onlynotesswent.model.users
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.firestore
@@ -29,13 +31,9 @@ class UserViewModel(private val repository: UserRepository) : ViewModel() {
   }
 
   companion object {
-    val Factory: ViewModelProvider.Factory =
-        object : ViewModelProvider.Factory {
-          @Suppress("UNCHECKED_CAST")
-          override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return UserViewModel(UserRepositoryFirestore(Firebase.firestore)) as T
-          }
-        }
+    val Factory: ViewModelProvider.Factory = viewModelFactory {
+      initializer { UserViewModel(UserRepositoryFirestore(Firebase.firestore)) }
+    }
   }
 
   /**

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/AddNote.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/AddNote.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.unit.dp
 import com.github.onlynotesswent.R
 import com.github.onlynotesswent.model.note.Note
 import com.github.onlynotesswent.model.note.NoteViewModel
-import com.github.onlynotesswent.model.note.Type
 import com.github.onlynotesswent.model.scanner.Scanner
 import com.github.onlynotesswent.model.users.UserViewModel
 import com.github.onlynotesswent.ui.navigation.NavigationActions
@@ -56,7 +55,7 @@ fun AddNoteScreen(
 
   var title by remember { mutableStateOf("") }
   var template by remember { mutableStateOf("Choose An Option") }
-  var visibility by remember { mutableStateOf("Choose An Option") }
+  var visibility: Note.Visibility? by remember { mutableStateOf(null) }
   var expandedVisibility by remember { mutableStateOf(false) }
   var expandedTemplate by remember { mutableStateOf(false) }
   var saveButton by remember { mutableStateOf("Create Note") }
@@ -104,13 +103,13 @@ fun AddNoteScreen(
               Spacer(modifier = Modifier.height(30.dp))
 
               OptionDropDownMenu(
-                  value = visibility,
+                  value = visibility?.toReadableString() ?: "Choose an option",
                   expanded = expandedVisibility,
                   buttonTag = "visibilityButton",
                   menuTag = "visibilityMenu",
                   onExpandedChange = { expandedVisibility = it },
-                  items = listOf("Public", "Private"),
-                  onItemClick = { visibility = it })
+                  items = Note.Visibility.READABLE_STRINGS,
+                  onItemClick = { visibility = Note.Visibility.fromReadableString(it) })
 
               Spacer(modifier = Modifier.height(30.dp))
 
@@ -135,13 +134,13 @@ fun AddNoteScreen(
 
               Button(
                   onClick = {
-                    var type = Type.NORMAL_TEXT
+                    var type = Note.Type.NORMAL_TEXT
                     if (saveButton == "Take Picture") {
                       // call scan image API or functions. Once scanned, add the note to database
                       scanner.scan()
-                      type = Type.PDF
+                      type = Note.Type.PDF
                     } else if (saveButton == "Create Note") {
-                      type = Type.NORMAL_TEXT
+                      type = Note.Type.NORMAL_TEXT
                     }
 
                     // create the note and add it to database
@@ -153,16 +152,14 @@ fun AddNoteScreen(
                             title = title,
                             content = "",
                             date = Timestamp.now(),
-                            public = (visibility == "Public"),
+                            visibility = visibility!!,
                             userId = userViewModel.currentUser.value!!.uid,
                             image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)),
                         userViewModel.currentUser.value!!.uid)
                     navigationActions.goBack()
                   },
                   enabled =
-                      title.isNotEmpty() &&
-                          visibility != "Choose An Option" &&
-                          template != "Choose An Option",
+                      title.isNotEmpty() && visibility != null && template != "Choose An Option",
                   modifier = Modifier.fillMaxWidth().testTag("createNoteButton")) {
                     Text(text = saveButton)
                   }

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/AddNote.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/AddNote.kt
@@ -32,15 +32,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.onlynotesswent.R
 import com.github.onlynotesswent.model.note.Note
 import com.github.onlynotesswent.model.note.NoteViewModel
 import com.github.onlynotesswent.model.note.Type
 import com.github.onlynotesswent.model.scanner.Scanner
+import com.github.onlynotesswent.model.users.UserViewModel
 import com.github.onlynotesswent.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
 
@@ -49,7 +50,8 @@ import com.google.firebase.Timestamp
 fun AddNoteScreen(
     navigationActions: NavigationActions,
     scanner: Scanner,
-    noteViewModel: NoteViewModel = viewModel(factory = NoteViewModel.Factory),
+    noteViewModel: NoteViewModel,
+    userViewModel: UserViewModel
 ) {
 
   var title by remember { mutableStateOf("") }
@@ -58,6 +60,8 @@ fun AddNoteScreen(
   var expandedVisibility by remember { mutableStateOf(false) }
   var expandedTemplate by remember { mutableStateOf(false) }
   var saveButton by remember { mutableStateOf("Create Note") }
+
+  val context = LocalContext.current
 
   Scaffold(
       modifier = Modifier.testTag("addNoteScreen"),
@@ -139,6 +143,7 @@ fun AddNoteScreen(
                     } else if (saveButton == "Create Note") {
                       type = Type.NORMAL_TEXT
                     }
+
                     // create the note and add it to database
                     noteViewModel.addNote(
                         // provisional note, we will have to change this later
@@ -149,9 +154,9 @@ fun AddNoteScreen(
                             content = "",
                             date = Timestamp.now(),
                             public = (visibility == "Public"),
-                            userId = "1",
+                            userId = userViewModel.currentUser.value!!.uid,
                             image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)),
-                        "1")
+                        userViewModel.currentUser.value!!.uid)
                     navigationActions.goBack()
                   },
                   enabled =

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.github.onlynotesswent.model.note.Note
 import com.github.onlynotesswent.model.note.NoteViewModel
-import com.github.onlynotesswent.model.note.Type
 import com.github.onlynotesswent.model.users.UserViewModel
 import com.github.onlynotesswent.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
@@ -43,7 +42,7 @@ fun EditNoteScreen(
     noteViewModel: NoteViewModel,
     userViewModel: UserViewModel
 ) {
-  val note by noteViewModel.note.collectAsState()
+  val note by noteViewModel.selectedNote.collectAsState()
   var updatedNoteText by remember { mutableStateOf(note?.content ?: "") } // Keep track of changes
   var updatedNoteTitle by remember { mutableStateOf(note?.title ?: "") } // Keep track of changes
 
@@ -72,11 +71,11 @@ fun EditNoteScreen(
               noteViewModel.updateNote(
                   Note(
                       id = note?.id ?: "1",
-                      type = Type.NORMAL_TEXT,
+                      type = Note.Type.NORMAL_TEXT,
                       title = updatedNoteTitle,
                       content = updatedNoteText,
                       date = Timestamp.now(), // Use current timestamp
-                      public = note?.public ?: true,
+                      visibility = note?.visibility ?: Note.Visibility.DEFAULT,
                       userId = note?.userId ?: userViewModel.currentUser.value!!.uid,
                       image =
                           note?.image

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import com.github.onlynotesswent.model.note.Note
 import com.github.onlynotesswent.model.note.NoteViewModel
 import com.github.onlynotesswent.model.note.Type
+import com.github.onlynotesswent.model.users.UserViewModel
 import com.github.onlynotesswent.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
 
@@ -37,7 +38,11 @@ import com.google.firebase.Timestamp
  *   updates.
  */
 @Composable
-fun EditNoteScreen(navigationActions: NavigationActions, noteViewModel: NoteViewModel) {
+fun EditNoteScreen(
+    navigationActions: NavigationActions,
+    noteViewModel: NoteViewModel,
+    userViewModel: UserViewModel
+) {
   val note by noteViewModel.note.collectAsState()
   var updatedNoteText by remember { mutableStateOf(note?.content ?: "") } // Keep track of changes
   var updatedNoteTitle by remember { mutableStateOf(note?.title ?: "") } // Keep track of changes
@@ -72,13 +77,13 @@ fun EditNoteScreen(navigationActions: NavigationActions, noteViewModel: NoteView
                       content = updatedNoteText,
                       date = Timestamp.now(), // Use current timestamp
                       public = note?.public ?: true,
-                      userId = note?.userId ?: "1",
+                      userId = note?.userId ?: userViewModel.currentUser.value!!.uid,
                       image =
                           note?.image
                               ?: Bitmap.createBitmap(
                                   1, 1, Bitmap.Config.ARGB_8888) // Placeholder Bitmap
                       ),
-                  "1")
+                  userViewModel.currentUser.value!!.uid)
               navigationActions.goBack()
             },
             modifier = Modifier.testTag("Save button")) {

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/Overview.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/Overview.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -14,8 +15,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -31,6 +34,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.github.onlynotesswent.model.note.Note
 import com.github.onlynotesswent.model.note.NoteViewModel
+import com.github.onlynotesswent.model.users.UserViewModel
 import com.github.onlynotesswent.ui.navigation.BottomNavigationMenu
 import com.github.onlynotesswent.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.onlynotesswent.ui.navigation.NavigationActions
@@ -47,8 +51,13 @@ import java.util.Locale
  * @param noteViewModel The ViewModel that provides the list of notes to display.
  */
 @Composable
-fun OverviewScreen(navigationActions: NavigationActions, noteViewModel: NoteViewModel) {
-  val notes = noteViewModel.notes.collectAsState()
+fun OverviewScreen(
+    navigationActions: NavigationActions,
+    noteViewModel: NoteViewModel,
+    userViewModel: UserViewModel
+) {
+  val allNotes = noteViewModel.notes.collectAsState()
+  val notes = allNotes.value.filter { it.userId == userViewModel.currentUser.value?.uid }
 
   Scaffold(
       modifier = Modifier.testTag("overviewScreen"),
@@ -65,8 +74,8 @@ fun OverviewScreen(navigationActions: NavigationActions, noteViewModel: NoteView
             tabList = LIST_TOP_LEVEL_DESTINATION,
             selectedItem = navigationActions.currentRoute())
       }) { pd ->
-        Box {
-          if (notes.value.isNotEmpty()) {
+        Box(modifier = Modifier.fillMaxSize().padding(pd)) {
+          if (notes.isNotEmpty()) {
             LazyColumn(
                 contentPadding = PaddingValues(vertical = 40.dp),
                 modifier =
@@ -74,17 +83,31 @@ fun OverviewScreen(navigationActions: NavigationActions, noteViewModel: NoteView
                         .padding(horizontal = 16.dp)
                         .padding(pd)
                         .testTag("noteList")) {
-                  items(notes.value.size) { index ->
-                    NoteItem(note = notes.value[index]) {
-                      noteViewModel.selectedNote(notes.value[index])
+                  items(notes.size) { index ->
+                    NoteItem(note = notes[index]) {
+                      noteViewModel.selectedNote(notes[index])
                       navigationActions.navigateTo(Screen.EDIT_NOTE)
                     }
                   }
                 }
           } else {
-            Text(
-                modifier = Modifier.padding(pd).testTag("emptyNotePrompt"),
-                text = "You have no Notes yet.")
+            Column(
+                modifier = Modifier.fillMaxSize().padding(pd),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+              Text(modifier = Modifier.testTag("emptyNotePrompt"), text = "You have no Notes yet.")
+              Spacer(modifier = Modifier.height(50.dp))
+              ElevatedButton(
+                  modifier = Modifier.testTag("refreshButton"),
+                  onClick = {
+                    userViewModel.currentUser.value?.let { noteViewModel.getNotes(it.uid) }
+                  }) {
+                    Text("Refresh")
+                    Icon(imageVector = Icons.Default.Refresh, contentDescription = "Refresh")
+                  }
+              Spacer(modifier = Modifier.height(20.dp))
+            }
           }
         }
       }

--- a/app/src/main/java/com/github/onlynotesswent/ui/search/Search.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/search/Search.kt
@@ -34,12 +34,12 @@ import com.github.onlynotesswent.ui.overview.NoteItem
  * Displays the search screen where users can search notes by title.
  *
  * @param navigationActions The navigation view model used to transition between different screens.
- * @param noteViewModel The ViewModel that provides the list of notes to search from.
+ * @param noteViewModel The ViewModel that provides the list of publicNotes to search from.
  */
 @Composable
 fun SearchScreen(navigationActions: NavigationActions, noteViewModel: NoteViewModel) {
   var searchQuery by remember { mutableStateOf(TextFieldValue("")) }
-  val notes = noteViewModel.notes.collectAsState()
+  val notes = noteViewModel.publicNotes.collectAsState()
 
   val filteredNotes = notes.value.filter { it.title.contains(searchQuery.text, ignoreCase = true) }
 
@@ -48,7 +48,10 @@ fun SearchScreen(navigationActions: NavigationActions, noteViewModel: NoteViewMo
       topBar = {
         OutlinedTextField(
             value = searchQuery,
-            onValueChange = { searchQuery = it },
+            onValueChange = {
+              searchQuery = it
+              noteViewModel.getPublicNotes()
+            },
             placeholder = { Text("Search ...") },
             leadingIcon = {
               Icon(

--- a/app/src/main/java/com/github/onlynotesswent/ui/user/CreateUser.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/user/CreateUser.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import com.github.onlynotesswent.model.note.NoteViewModel
 import com.github.onlynotesswent.model.users.User
 import com.github.onlynotesswent.model.users.UserRepositoryFirestore
 import com.github.onlynotesswent.model.users.UserViewModel
@@ -44,7 +45,11 @@ import com.google.firebase.auth.auth
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CreateUserScreen(navigationActions: NavigationActions, userViewModel: UserViewModel) {
+fun CreateUserScreen(
+    navigationActions: NavigationActions,
+    noteViewModel: NoteViewModel,
+    userViewModel: UserViewModel
+) {
   // State variables to hold user input
   val firstName = remember { mutableStateOf("") }
   val lastName = remember { mutableStateOf("") }
@@ -96,6 +101,7 @@ fun CreateUserScreen(navigationActions: NavigationActions, userViewModel: UserVi
                         user = user,
                         onSuccess = {
                           userViewModel.setCurrentUser(user)
+                          noteViewModel.getNotes(userID = user.uid)
                           navigationActions.navigateTo(Screen.OVERVIEW)
                         },
                         onFailure = { exception ->

--- a/app/src/main/java/com/github/onlynotesswent/ui/user/CreateUser.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/user/CreateUser.kt
@@ -92,9 +92,7 @@ fun CreateUserScreen(navigationActions: NavigationActions, userViewModel: UserVi
                             rating = 0.0)
                     userViewModel.addUser(
                         user = user,
-                        onSuccess = {
-                          navigationActions.navigateTo(TopLevelDestinations.OVERVIEW)
-                        },
+                        onSuccess = { navigationActions.navigateTo(TopLevelDestinations.OVERVIEW) },
                         onFailure = { exception ->
                           Toast.makeText(
                                   context,

--- a/app/src/main/java/com/github/onlynotesswent/ui/user/CreateUser.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/user/CreateUser.kt
@@ -18,21 +18,18 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import com.github.onlynotesswent.model.note.NoteViewModel
 import com.github.onlynotesswent.model.users.User
 import com.github.onlynotesswent.model.users.UserRepositoryFirestore
 import com.github.onlynotesswent.model.users.UserViewModel
 import com.github.onlynotesswent.ui.authentication.Logo
 import com.github.onlynotesswent.ui.navigation.NavigationActions
-import com.github.onlynotesswent.ui.navigation.Screen
+import com.github.onlynotesswent.ui.navigation.TopLevelDestinations
 import com.google.firebase.Firebase
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.auth
@@ -45,11 +42,7 @@ import com.google.firebase.auth.auth
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CreateUserScreen(
-    navigationActions: NavigationActions,
-    noteViewModel: NoteViewModel,
-    userViewModel: UserViewModel
-) {
+fun CreateUserScreen(navigationActions: NavigationActions, userViewModel: UserViewModel) {
   // State variables to hold user input
   val firstName = remember { mutableStateOf("") }
   val lastName = remember { mutableStateOf("") }
@@ -101,8 +94,7 @@ fun CreateUserScreen(
                         user = user,
                         onSuccess = {
                           userViewModel.setCurrentUser(user)
-                          noteViewModel.getNotes(userID = user.uid)
-                          navigationActions.navigateTo(Screen.OVERVIEW)
+                          navigationActions.navigateTo(TopLevelDestinations.OVERVIEW)
                         },
                         onFailure = { exception ->
                           Toast.makeText(

--- a/app/src/main/java/com/github/onlynotesswent/ui/user/EditProfile.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/user/EditProfile.kt
@@ -15,21 +15,18 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import com.github.onlynotesswent.model.note.NoteViewModel
 import com.github.onlynotesswent.model.users.User
 import com.github.onlynotesswent.model.users.UserRepositoryFirestore
 import com.github.onlynotesswent.model.users.UserViewModel
 import com.github.onlynotesswent.ui.navigation.BottomNavigationMenu
 import com.github.onlynotesswent.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.onlynotesswent.ui.navigation.NavigationActions
-import com.github.onlynotesswent.ui.navigation.Screen
+import com.github.onlynotesswent.ui.navigation.TopLevelDestinations
 
 /**
  * A composable function that displays the profile screen.
@@ -41,7 +38,6 @@ import com.github.onlynotesswent.ui.navigation.Screen
 @Composable
 fun ProfileScreen(
     navigationActions: NavigationActions,
-    noteViewModel: NoteViewModel,
     userViewModel: UserViewModel
 ) {
   val user = userViewModel.currentUser.collectAsState()
@@ -111,8 +107,7 @@ fun ProfileScreen(
                           user = updatedUser,
                           onSuccess = {
                             userViewModel.setCurrentUser(updatedUser)
-                            noteViewModel.getNotes(userID = updatedUser.uid)
-                            navigationActions.navigateTo(Screen.OVERVIEW)
+                            navigationActions.navigateTo(TopLevelDestinations.OVERVIEW)
                           },
                           onFailure = { exception ->
                             Toast.makeText(

--- a/app/src/main/java/com/github/onlynotesswent/ui/user/EditProfile.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/user/EditProfile.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import com.github.onlynotesswent.model.note.NoteViewModel
 import com.github.onlynotesswent.model.users.User
 import com.github.onlynotesswent.model.users.UserRepositoryFirestore
 import com.github.onlynotesswent.model.users.UserViewModel
@@ -38,7 +39,11 @@ import com.github.onlynotesswent.ui.navigation.Screen
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ProfileScreen(navigationActions: NavigationActions, userViewModel: UserViewModel) {
+fun ProfileScreen(
+    navigationActions: NavigationActions,
+    noteViewModel: NoteViewModel,
+    userViewModel: UserViewModel
+) {
   val user = userViewModel.currentUser.collectAsState()
 
   val newFirstName = remember { mutableStateOf(user.value?.firstName ?: "") }
@@ -106,6 +111,7 @@ fun ProfileScreen(navigationActions: NavigationActions, userViewModel: UserViewM
                           user = updatedUser,
                           onSuccess = {
                             userViewModel.setCurrentUser(updatedUser)
+                            noteViewModel.getNotes(userID = updatedUser.uid)
                             navigationActions.navigateTo(Screen.OVERVIEW)
                           },
                           onFailure = { exception ->

--- a/app/src/main/java/com/github/onlynotesswent/ui/user/EditProfile.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/user/EditProfile.kt
@@ -36,10 +36,7 @@ import com.github.onlynotesswent.ui.navigation.TopLevelDestinations
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ProfileScreen(
-    navigationActions: NavigationActions,
-    userViewModel: UserViewModel
-) {
+fun ProfileScreen(navigationActions: NavigationActions, userViewModel: UserViewModel) {
   val user = userViewModel.currentUser.collectAsState()
 
   val newFirstName = remember { mutableStateOf(user.value?.firstName ?: "") }
@@ -105,7 +102,9 @@ fun ProfileScreen(
                     } else {
                       userViewModel.updateUser(
                           user = updatedUser,
-                          onSuccess = { navigationActions.navigateTo(TopLevelDestinations.OVERVIEW) },
+                          onSuccess = {
+                            navigationActions.navigateTo(TopLevelDestinations.OVERVIEW)
+                          },
                           onFailure = { exception ->
                             Toast.makeText(
                                     context,

--- a/app/src/test/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestoreTest.kt
@@ -13,7 +13,6 @@ import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
-import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
 import org.junit.Before
 import org.junit.Test
@@ -52,15 +51,15 @@ class NoteRepositoryFirestoreTest {
           image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
 
   private val testNotePrivate =
-    Note(
-      id = "1",
-      type = Note.Type.NORMAL_TEXT,
-      title = "title",
-      content = "content",
-      date = Timestamp.now(),
-      visibility = Note.Visibility.PRIVATE,
-      userId = "1",
-      image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
+      Note(
+          id = "1",
+          type = Note.Type.NORMAL_TEXT,
+          title = "title",
+          content = "content",
+          date = Timestamp.now(),
+          visibility = Note.Visibility.PRIVATE,
+          userId = "1",
+          image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
 
   @Before
   fun setUp() {
@@ -80,39 +79,38 @@ class NoteRepositoryFirestoreTest {
     `when`(mockQuerySnapshotTask.result).thenReturn(mockQuerySnapshot)
     `when`(mockQuerySnapshotTask.isSuccessful).thenReturn(true)
     `when`(mockQuerySnapshotTask.addOnCompleteListener(any())).thenAnswer { invocation ->
-      val listener =
-        invocation.getArgument<OnCompleteListener<QuerySnapshot>>(0)
+      val listener = invocation.getArgument<OnCompleteListener<QuerySnapshot>>(0)
       // Simulate a result being passed to the listener
       listener.onComplete(mockQuerySnapshotTask)
-        mockQuerySnapshotTask
+      mockQuerySnapshotTask
     }
 
     // Ensure the documents field is properly initialized
-    `when`(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot, mockDocumentSnapshot2))
-
+    `when`(mockQuerySnapshot.documents)
+        .thenReturn(listOf(mockDocumentSnapshot, mockDocumentSnapshot2))
 
     `when`(mockDocumentSnapshot.id).thenReturn(testNotePublic.id)
     `when`(mockDocumentSnapshot.getString("type")).thenReturn(testNotePublic.type.toString())
     `when`(mockDocumentSnapshot.getString("title")).thenReturn(testNotePublic.title)
     `when`(mockDocumentSnapshot.getString("content")).thenReturn(testNotePublic.content)
     `when`(mockDocumentSnapshot.getTimestamp("date")).thenReturn(testNotePublic.date)
-    `when`(mockDocumentSnapshot.getString("visibility")).thenReturn(testNotePublic.visibility.toString())
+    `when`(mockDocumentSnapshot.getString("visibility"))
+        .thenReturn(testNotePublic.visibility.toString())
     `when`(mockDocumentSnapshot.getString("userId")).thenReturn(testNotePublic.userId)
     `when`(mockDocumentSnapshot.get("image")).thenReturn(testNotePublic.image)
-
 
     `when`(mockDocumentSnapshot2.id).thenReturn(testNotePrivate.id)
     `when`(mockDocumentSnapshot2.getString("type")).thenReturn(testNotePrivate.type.toString())
     `when`(mockDocumentSnapshot2.getString("title")).thenReturn(testNotePrivate.title)
     `when`(mockDocumentSnapshot2.getString("content")).thenReturn(testNotePrivate.content)
     `when`(mockDocumentSnapshot2.getTimestamp("date")).thenReturn(testNotePrivate.date)
-    `when`(mockDocumentSnapshot2.getString("visibility")).thenReturn(testNotePrivate.visibility.toString())
+    `when`(mockDocumentSnapshot2.getString("visibility"))
+        .thenReturn(testNotePrivate.visibility.toString())
     `when`(mockDocumentSnapshot2.getString("userId")).thenReturn(testNotePrivate.userId)
     `when`(mockDocumentSnapshot2.get("image")).thenReturn(testNotePrivate.image)
-
   }
 
-  private fun compareNotesButNotImage(note1:Note,note2:Note) {
+  private fun compareNotesButNotImage(note1: Note, note2: Note) {
     assert(note1.id == note2.id)
     assert(note1.type == note2.type)
     assert(note1.title == note2.title)
@@ -135,30 +133,33 @@ class NoteRepositoryFirestoreTest {
     val resultingNote = noteRepositoryFirestore.documentSnapshotToNote(mockDocumentSnapshot)
 
     assertNotNull(resultingNote)
-    compareNotesButNotImage(resultingNote!!,testNotePublic)
+    compareNotesButNotImage(resultingNote!!, testNotePublic)
   }
 
   @Test
   fun `getPublicNotes callsDocuments`() {
 
-    `when`(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot,mockDocumentSnapshot2))
+    `when`(mockQuerySnapshot.documents)
+        .thenReturn(listOf(mockDocumentSnapshot, mockDocumentSnapshot2))
 
     var receivedNotes: List<Note>? = null
-    noteRepositoryFirestore.getPublicNotes({receivedNotes=it}, {assert(false)})
+    noteRepositoryFirestore.getPublicNotes({ receivedNotes = it }, { assert(false) })
 
     assertNotNull(receivedNotes)
     assert(receivedNotes!!.size == 1)
-    compareNotesButNotImage(receivedNotes?.get(0)!!,testNotePublic)
+    compareNotesButNotImage(receivedNotes?.get(0)!!, testNotePublic)
     verify(timeout(100)) { mockQuerySnapshot.documents }
   }
 
   @Test
   fun getNotesFrom_callsDocuments() {
     // Ensure the QuerySnapshot returns a list of mock DocumentSnapshots
-    `when`(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot,mockDocumentSnapshot2))
+    `when`(mockQuerySnapshot.documents)
+        .thenReturn(listOf(mockDocumentSnapshot, mockDocumentSnapshot2))
 
     var receivedNotes: List<Note>? = null
-    noteRepositoryFirestore.getNotesFrom(testNotePublic.userId,{receivedNotes=it}, {assert(false)})
+    noteRepositoryFirestore.getNotesFrom(
+        testNotePublic.userId, { receivedNotes = it }, { assert(false) })
     assertNotNull(receivedNotes)
     assert(receivedNotes?.size == 2)
 

--- a/app/src/test/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestoreTest.kt
@@ -3,6 +3,8 @@ package com.github.onlynotesswent.model.note
 import android.graphics.Bitmap
 import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.FirebaseApp
 import com.google.firebase.Timestamp
@@ -11,6 +13,7 @@ import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
+import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
 import org.junit.Before
 import org.junit.Test
@@ -31,20 +34,33 @@ class NoteRepositoryFirestoreTest {
   @Mock private lateinit var mockDocumentReference: DocumentReference
   @Mock private lateinit var mockCollectionReference: CollectionReference
   @Mock private lateinit var mockDocumentSnapshot: DocumentSnapshot
-  @Mock private lateinit var mockToDoQuerySnapshot: QuerySnapshot
+  @Mock private lateinit var mockDocumentSnapshot2: DocumentSnapshot
+  @Mock private lateinit var mockQuerySnapshot: QuerySnapshot
+  @Mock private lateinit var mockQuerySnapshotTask: Task<QuerySnapshot>
 
   private lateinit var noteRepositoryFirestore: NoteRepositoryFirestore
 
-  private val note =
+  private val testNotePublic =
       Note(
           id = "1",
-          type = Type.NORMAL_TEXT,
+          type = Note.Type.NORMAL_TEXT,
           title = "title",
           content = "content",
           date = Timestamp.now(),
-          public = true,
+          visibility = Note.Visibility.PUBLIC,
           userId = "1",
           image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
+
+  private val testNotePrivate =
+    Note(
+      id = "1",
+      type = Note.Type.NORMAL_TEXT,
+      title = "title",
+      content = "content",
+      date = Timestamp.now(),
+      visibility = Note.Visibility.PRIVATE,
+      userId = "1",
+      image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
 
   @Before
   fun setUp() {
@@ -59,6 +75,51 @@ class NoteRepositoryFirestoreTest {
     `when`(mockFirestore.collection(any())).thenReturn(mockCollectionReference)
     `when`(mockCollectionReference.document(any())).thenReturn(mockDocumentReference)
     `when`(mockCollectionReference.document()).thenReturn(mockDocumentReference)
+
+    `when`(mockCollectionReference.get()).thenReturn(mockQuerySnapshotTask)
+    `when`(mockQuerySnapshotTask.result).thenReturn(mockQuerySnapshot)
+    `when`(mockQuerySnapshotTask.isSuccessful).thenReturn(true)
+    `when`(mockQuerySnapshotTask.addOnCompleteListener(any())).thenAnswer { invocation ->
+      val listener =
+        invocation.getArgument<OnCompleteListener<QuerySnapshot>>(0)
+      // Simulate a result being passed to the listener
+      listener.onComplete(mockQuerySnapshotTask)
+        mockQuerySnapshotTask
+    }
+
+    // Ensure the documents field is properly initialized
+    `when`(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot, mockDocumentSnapshot2))
+
+
+    `when`(mockDocumentSnapshot.id).thenReturn(testNotePublic.id)
+    `when`(mockDocumentSnapshot.getString("type")).thenReturn(testNotePublic.type.toString())
+    `when`(mockDocumentSnapshot.getString("title")).thenReturn(testNotePublic.title)
+    `when`(mockDocumentSnapshot.getString("content")).thenReturn(testNotePublic.content)
+    `when`(mockDocumentSnapshot.getTimestamp("date")).thenReturn(testNotePublic.date)
+    `when`(mockDocumentSnapshot.getString("visibility")).thenReturn(testNotePublic.visibility.toString())
+    `when`(mockDocumentSnapshot.getString("userId")).thenReturn(testNotePublic.userId)
+    `when`(mockDocumentSnapshot.get("image")).thenReturn(testNotePublic.image)
+
+
+    `when`(mockDocumentSnapshot2.id).thenReturn(testNotePrivate.id)
+    `when`(mockDocumentSnapshot2.getString("type")).thenReturn(testNotePrivate.type.toString())
+    `when`(mockDocumentSnapshot2.getString("title")).thenReturn(testNotePrivate.title)
+    `when`(mockDocumentSnapshot2.getString("content")).thenReturn(testNotePrivate.content)
+    `when`(mockDocumentSnapshot2.getTimestamp("date")).thenReturn(testNotePrivate.date)
+    `when`(mockDocumentSnapshot2.getString("visibility")).thenReturn(testNotePrivate.visibility.toString())
+    `when`(mockDocumentSnapshot2.getString("userId")).thenReturn(testNotePrivate.userId)
+    `when`(mockDocumentSnapshot2.get("image")).thenReturn(testNotePrivate.image)
+
+  }
+
+  private fun compareNotesButNotImage(note1:Note,note2:Note) {
+    assert(note1.id == note2.id)
+    assert(note1.type == note2.type)
+    assert(note1.title == note2.title)
+    assert(note1.content == note2.content)
+    assert(note1.date == note2.date)
+    assert(note1.visibility == note2.visibility)
+    assert(note1.userId == note2.userId)
   }
 
   @Test
@@ -70,43 +131,39 @@ class NoteRepositoryFirestoreTest {
 
   @Test
   fun documentSnapshotToNoteConvertsSnapshotToNote() {
-    val currentTime = Timestamp.now()
 
-    `when`(mockDocumentSnapshot.id).thenReturn("1")
-    `when`(mockDocumentSnapshot.getString("type")).thenReturn(Type.NORMAL_TEXT.name)
-    `when`(mockDocumentSnapshot.getString("title")).thenReturn("title")
-    `when`(mockDocumentSnapshot.getString("content")).thenReturn("content")
-    `when`(mockDocumentSnapshot.getTimestamp("date")).thenReturn(currentTime)
-    `when`(mockDocumentSnapshot.getBoolean("public")).thenReturn(true)
-    `when`(mockDocumentSnapshot.getString("userId")).thenReturn("1")
-    val bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
-    `when`(mockDocumentSnapshot.get("image")).thenReturn(bitmap)
+    val resultingNote = noteRepositoryFirestore.documentSnapshotToNote(mockDocumentSnapshot)
 
-    val note = noteRepositoryFirestore.documentSnapshotToNote(mockDocumentSnapshot)
-
-    assertNotNull(note)
-    assert(note?.id == "1")
-    assert(note?.type == Type.NORMAL_TEXT)
-    assert(note?.title == "title")
-    assert(note?.content == "content")
-    assert(note?.date == currentTime)
-    assert(note?.public == true)
-    assert(note?.userId == "1")
-    note?.image?.let { assert(it.sameAs(bitmap)) }
+    assertNotNull(resultingNote)
+    compareNotesButNotImage(resultingNote!!,testNotePublic)
   }
 
   @Test
-  fun getNotes_callsDocuments() {
-    // Ensure that mockToDoQuerySnapshot is properly initialized and mocked
-    `when`(mockCollectionReference.get()).thenReturn(Tasks.forResult(mockToDoQuerySnapshot))
+  fun `getPublicNotes callsDocuments`() {
 
+    `when`(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot,mockDocumentSnapshot2))
+
+    var receivedNotes: List<Note>? = null
+    noteRepositoryFirestore.getPublicNotes({receivedNotes=it}, {assert(false)})
+
+    assertNotNull(receivedNotes)
+    assert(receivedNotes!!.size == 1)
+    compareNotesButNotImage(receivedNotes?.get(0)!!,testNotePublic)
+    verify(timeout(100)) { mockQuerySnapshot.documents }
+  }
+
+  @Test
+  fun getNotesFrom_callsDocuments() {
     // Ensure the QuerySnapshot returns a list of mock DocumentSnapshots
-    `when`(mockToDoQuerySnapshot.documents).thenReturn(listOf())
+    `when`(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot,mockDocumentSnapshot2))
 
-    noteRepositoryFirestore.getNotes("1", {}, {})
+    var receivedNotes: List<Note>? = null
+    noteRepositoryFirestore.getNotesFrom(testNotePublic.userId,{receivedNotes=it}, {assert(false)})
+    assertNotNull(receivedNotes)
+    assert(receivedNotes?.size == 2)
 
     // Verify that the 'documents' field was accessed
-    verify(timeout(100)) { (mockToDoQuerySnapshot).documents }
+    verify(timeout(100)) { (mockQuerySnapshot).documents }
   }
 
   @Test
@@ -124,13 +181,13 @@ class NoteRepositoryFirestoreTest {
   fun addNote_callsCollection() {
     `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null))
 
-    // This test verifies that when we add a new ToDo, the Firestore `collection()` method is
+    // This test verifies that when we add a new note, the Firestore `collection()` method is
     // called.
-    noteRepositoryFirestore.addNote(note, onSuccess = {}, onFailure = {})
+    noteRepositoryFirestore.addNote(testNotePublic, onSuccess = {}, onFailure = {})
 
     shadowOf(Looper.getMainLooper()).idle() // Ensure all asynchronous operations complete
 
-    // Ensure Firestore collection method was called to reference the notes collection
+    // Ensure Firestore collection method was called to reference the publicNotes collection
     verify(mockDocumentReference).set(any())
   }
 
@@ -149,7 +206,7 @@ class NoteRepositoryFirestoreTest {
   fun updateNote_callsCollection() {
     `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null))
 
-    noteRepositoryFirestore.updateNote(note, onSuccess = {}, onFailure = {})
+    noteRepositoryFirestore.updateNote(testNotePublic, onSuccess = {}, onFailure = {})
 
     shadowOf(Looper.getMainLooper()).idle()
 

--- a/app/src/test/java/com/github/onlynotesswent/model/note/NoteViewModelTest.kt
+++ b/app/src/test/java/com/github/onlynotesswent/model/note/NoteViewModelTest.kt
@@ -19,14 +19,14 @@ class NoteViewModelTest {
   private lateinit var noteRepository: NoteRepository
   private lateinit var noteViewModel: NoteViewModel
 
-  private val note =
+  private val testNote =
       Note(
           id = "1",
-          type = Type.NORMAL_TEXT,
+          type = Note.Type.NORMAL_TEXT,
           title = "title",
           content = "content",
           date = Timestamp.now(),
-          public = true,
+          visibility = Note.Visibility.DEFAULT,
           userId = "1",
           image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
 
@@ -43,9 +43,20 @@ class NoteViewModelTest {
   }
 
   @Test
-  fun getNotesCallsRepository() {
-    noteViewModel.getNotes("1")
-    verify(noteRepository).getNotes(eq("1"), any(), any())
+  fun initCallsRepository() {
+    verify(noteRepository).init(any())
+  }
+
+  @Test
+  fun getPublicNotesCallsRepository() {
+    noteViewModel.getPublicNotes()
+    verify(noteRepository).getPublicNotes(any(), any())
+  }
+
+  @Test
+  fun getNotesFromCallsRepository() {
+    noteViewModel.getNotesFrom("1")
+    verify(noteRepository).getNotesFrom(eq("1"), any(), any())
   }
 
   @Test
@@ -56,14 +67,14 @@ class NoteViewModelTest {
 
   @Test
   fun addNoteCallsRepository() {
-    noteViewModel.addNote(note, "1")
-    verify(noteRepository).addNote(eq(note), any(), any())
+    noteViewModel.addNote(testNote, "1")
+    verify(noteRepository).addNote(eq(testNote), any(), any())
   }
 
   @Test
   fun updateNoteCallsRepository() {
-    noteViewModel.updateNote(note, "1")
-    verify(noteRepository).updateNote(eq(note), any(), any())
+    noteViewModel.updateNote(testNote, "1")
+    verify(noteRepository).updateNote(eq(testNote), any(), any())
   }
 
   @Test


### PR DESCRIPTION
# Description

I have first fixed the overview so it would show user notes, but realised the search menu used the same list and didn't have access to public notes. 

To soon integrate all this with the friends feature I have reworked Note visibility with an enum and custom methods for display. The dropdown menus showing note visibility in AddNote now use these enum methods.  

I have also split the notes state flow in the NoteViewModel in two pieces: `publicNotes` and `userNotes`, which are updated by calling `getPublicNotes()` and `getNotesFrom(userID:String)` respectively. The note repository was adapted accordingly and new tests were added to cover this new behaviour.

Fixes #84 

# How Has This Been Tested?

I have added unit tests in NoteRepositoryFirestore which test the onCompleteListener behaviour, these can be used to model future tests. Alternatively, look to the tests I wrote in UserRepositoryFirestoreTest for guidance.

### Unit Tests
No new Unit tests, but some were updated.
  
### UI Tests
No new UI tests, but some were updated.

### End to end Tests
No end to end tests

  
# Dependencies
No new dependencies 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged in downstream modules, no conflicts with main
