### PR TITLE
fix: comment disappearing when editing a Note and saving the changes

### DIFF
--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/EditNoteTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/EditNoteTest.kt
@@ -85,8 +85,20 @@ class EditNoteTest {
     composeTestRule.onNodeWithTag("Add Comment Button").performScrollTo().assertIsDisplayed()
     composeTestRule.onNodeWithTag("Add Comment Button").performClick()
     composeTestRule.onNodeWithTag("EditCommentTextField").performScrollTo().assertIsDisplayed()
-    composeTestRule.onNodeWithTag("DeleteCommentButton").performClick()
-    composeTestRule.onNodeWithTag("EditCommentTextField").assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag("DeleteCommentButton").performScrollTo().performClick()
+    composeTestRule.onNodeWithTag("Save button").performScrollTo().assertIsDisplayed()
+  }
+
+  @Test
+  fun addCommentAndUpdateNote() {
+    composeTestRule.onNodeWithTag("Add Comment Button").performScrollTo().performClick()
+    composeTestRule.onNodeWithTag("EditCommentTextField").performScrollTo().assertIsDisplayed()
+    val updatedCommentText = "Edited comment content"
+    composeTestRule.onNodeWithTag("EditCommentTextField").performTextInput(updatedCommentText)
+    val expectedLabelText = "edited: "
+    composeTestRule.onNode(hasText(expectedLabelText, substring = true)).assertIsDisplayed()
+    composeTestRule.onNodeWithTag("Save button").performScrollTo().performClick()
+    composeTestRule.onNode(hasText(expectedLabelText, substring = true)).assertIsDisplayed()
   }
 
   @Test

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
@@ -201,8 +201,7 @@ fun EditNoteScreen(
                                   note?.image
                                       ?: Bitmap.createBitmap(
                                           1, 1, Bitmap.Config.ARGB_8888), // Placeholder Bitmap
-                              comments = updatedComments
-                              ),
+                              comments = updatedComments),
                           currentUser!!.uid)
                       if (note?.folderId != null) {
                         navigationActions.navigateTo(Screen.FOLDER_CONTENTS)

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
@@ -200,7 +200,8 @@ fun EditNoteScreen(
                               image =
                                   note?.image
                                       ?: Bitmap.createBitmap(
-                                          1, 1, Bitmap.Config.ARGB_8888) // Placeholder Bitmap
+                                          1, 1, Bitmap.Config.ARGB_8888), // Placeholder Bitmap
+                              comments = updatedComments
                               ),
                           currentUser!!.uid)
                       if (note?.folderId != null) {


### PR DESCRIPTION
Fixed a small bug that arise following the merge of the latest PR's where when creating a Note and adding a comment and then saving a note it and not having modified the comment or added any comment in the meantime the comments would disappear.

# Description

Simply re-added the fact that when a note was saved it would take into account the messages list.

# How Has This Been Tested?

Used the previous tests for the notes and comments that have been implemented. I also added a test to test this condition where we add comments then save a note going back to overview that the comments would not disappear in order for this issue to not arise again in new merges.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged in downstream modules, no conflicts with main
