### PR TITLE
CI: Add event to trigger Actions workflow for merge queues

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -2,6 +2,8 @@ name: Build APK
 
 on:
   workflow_dispatch:
+  pull_request:
+  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
# Description

This update enhances the GitHub Actions workflow by adding the `pull_request` and `merge_group` events as triggers. These events ensure that status checks are automatically triggered and reported when a pull request or a merge group is added to the queue.

These changes are necessary for configuring CI workflows to support merge queues. By adding the `pull_request` and `merge_group` events, queued PRs or grouped PRs receive the required status checks, preventing issues with unreported checks that would otherwise block merges.

Merge queues can be enabled once this PR is merged.

Fixes #121

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged in downstream modules, no conflicts with main
