### PR TITLE
CI: Add event to trigger Actions workflow for merge queues into main

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -10,6 +10,7 @@ on:
       - opened
       - synchronize
       - reopened
+  merge_group:
 
 jobs:
   ci:


### PR DESCRIPTION
# Description

This update enhances the GitHub Actions workflow by adding the `merge_group` event as triggers. This event ensure that status checks are automatically triggered and reported when a merge group is added to the queue.

These changes are necessary for configuring CI workflows to support merge queues. By adding the `merge_group` event,  grouped PRs receive the required status checks, preventing issues with unreported checks that would otherwise block merges.

Merge queues can be enabled once this PR is merged.

Fixes #121

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged in downstream modules, no conflicts with main