### PR TITLE
refactor: remove content and image from note

### DIFF
--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/EndToEndTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/EndToEndTest.kt
@@ -1,6 +1,5 @@
 package com.github.onlynotesswent.ui
 
-import android.graphics.Bitmap
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
@@ -122,12 +121,10 @@ class EndToEndTest {
       Note(
           id = "1",
           title = "title",
-          content = "",
           date = Timestamp.now(),
           userId = testUid,
           visibility = Visibility.DEFAULT,
-          noteCourse = Course("courseCode", "courseName", 2024, "publicPath"),
-          image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
+          noteCourse = Course("courseCode", "courseName", 2024, "publicPath"))
 
   // Setup Compose test rule for UI testing
   @get:Rule val composeTestRule = createComposeRule()

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/EditMarkdownTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/EditMarkdownTest.kt
@@ -64,17 +64,16 @@ class EditMarkdownTest {
             0.0)
     userViewModel.addUser(testUser, {}, {})
 
-      val testNote =
-          Note(
-              "testNoteId",
-              "testTitle",
-              Timestamp.now(),
-              Visibility.PUBLIC,
-              Course("CS-311", "SwEnt",
-                  2024, "testCoursePath"),
-                "testUserId")
+    val testNote =
+        Note(
+            "testNoteId",
+            "testTitle",
+            Timestamp.now(),
+            Visibility.PUBLIC,
+            Course("CS-311", "SwEnt", 2024, "testCoursePath"),
+            "testUserId")
 
-      noteViewModel.selectedNote(testNote)
+    noteViewModel.selectedNote(testNote)
 
     // Mock the current route to be the user create screen
     `when`(navigationActions.currentRoute()).thenReturn(Screen.EDIT_NOTE)

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/EditMarkdownTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/EditMarkdownTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import com.github.onlynotesswent.model.file.FileRepository
 import com.github.onlynotesswent.model.file.FileViewModel
+import com.github.onlynotesswent.model.note.Note
 import com.github.onlynotesswent.model.note.NoteRepository
 import com.github.onlynotesswent.model.note.NoteViewModel
 import com.github.onlynotesswent.model.users.User
@@ -16,12 +17,13 @@ import com.github.onlynotesswent.model.users.UserRepository
 import com.github.onlynotesswent.model.users.UserViewModel
 import com.github.onlynotesswent.ui.navigation.NavigationActions
 import com.github.onlynotesswent.ui.navigation.Screen
+import com.github.onlynotesswent.utils.Course
+import com.github.onlynotesswent.utils.Visibility
 import com.google.firebase.Timestamp
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
@@ -61,6 +63,18 @@ class EditMarkdownTest {
             Timestamp.now(),
             0.0)
     userViewModel.addUser(testUser, {}, {})
+
+      val testNote =
+          Note(
+              "testNoteId",
+              "testTitle",
+              Timestamp.now(),
+              Visibility.PUBLIC,
+              Course("CS-311", "SwEnt",
+                  2024, "testCoursePath"),
+                "testUserId")
+
+      noteViewModel.selectedNote(testNote)
 
     // Mock the current route to be the user create screen
     `when`(navigationActions.currentRoute()).thenReturn(Screen.EDIT_NOTE)

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/EditNoteTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/EditNoteTest.kt
@@ -1,6 +1,5 @@
 package com.github.onlynotesswent.ui.overview
 
-import android.graphics.Bitmap
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasText
@@ -69,13 +68,11 @@ class EditNoteTest {
         Note(
             id = "1",
             title = "Sample Title",
-            content = "This is a sample content.",
             date = Timestamp.now(), // Use current timestamp
             visibility = Visibility.DEFAULT,
             userId = "1",
             noteCourse = Course("CS-100", "Sample Class", 2024, "path"),
-            image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888) // Placeholder Bitmap
-            )
+        )
 
     `when`(noteRepository.getNoteById(any(), any(), any())).thenAnswer { invocation ->
       val onSuccess = invocation.getArgument<(Note) -> Unit>(1)

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/EditNoteTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/EditNoteTest.kt
@@ -148,7 +148,6 @@ class EditNoteTest {
     val expectedLabelText = "edited: "
     composeTestRule.onNode(hasText(expectedLabelText, substring = true)).assertIsDisplayed()
     composeTestRule.onNodeWithTag("Save button").performScrollTo().performClick()
-    composeTestRule.onNode(hasText(expectedLabelText, substring = true)).assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/FolderContentTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/FolderContentTest.kt
@@ -1,6 +1,5 @@
 package com.github.onlynotesswent.ui.overview
 
-import android.graphics.Bitmap
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -45,12 +44,11 @@ class FolderContentTest {
           Note(
               id = "1",
               title = "Sample Title",
-              content = "This is a sample content.",
               date = Timestamp.now(),
               visibility = Visibility.DEFAULT,
               userId = "1",
               noteCourse = Course("CS-100", "Sample Course", 2024, "path"),
-              image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)))
+          ))
 
   private val folderList =
       listOf(Folder(id = "1", name = "name", userId = "1", parentFolderId = null))

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/OverviewTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/OverviewTest.kt
@@ -1,6 +1,5 @@
 package com.github.onlynotesswent.ui.overview
 
-import android.graphics.Bitmap
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotDisplayed
@@ -47,13 +46,11 @@ class OverviewTest {
           Note(
               id = "1",
               title = "Sample Title",
-              content = "This is a sample content.",
               date = Timestamp.now(), // Use current timestamp
               visibility = Visibility.DEFAULT,
               userId = "1",
               noteCourse = Course("CS-100", "Sample Course", 2024, "path"),
-              image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888) // Placeholder Bitmap
-              ))
+          ))
 
   private val folderList =
       listOf(Folder(id = "1", name = "name", userId = "1", parentFolderId = null))

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/search/SearchTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/search/SearchTest.kt
@@ -1,6 +1,5 @@
 package com.github.onlynotesswent.ui.search
 
-import android.graphics.Bitmap
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.github.onlynotesswent.model.folder.Folder
@@ -41,22 +40,20 @@ class SearchScreenTest {
       Note(
           id = "",
           title = "Note 1",
-          content = "",
           date = Timestamp.now(),
           visibility = Visibility.PUBLIC,
           userId = "1",
           noteCourse = Course("CS-100", "Sample Course 1", 2024, "path"),
-          image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
+      )
   private val testNote2 =
       Note(
           id = "1",
           title = "Note 2",
-          content = "",
           date = Timestamp.now(),
           visibility = Visibility.PUBLIC,
           userId = "2",
           noteCourse = Course("CS-200", "Sample Course 2", 2024, "path"),
-          image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
+      )
 
   private val testNotes = listOf(testNote1, testNote2)
 

--- a/app/src/main/java/com/github/onlynotesswent/model/note/Note.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/note/Note.kt
@@ -1,21 +1,31 @@
 package com.github.onlynotesswent.model.note
 
-import android.graphics.Bitmap
 import com.github.onlynotesswent.utils.Course
 import com.github.onlynotesswent.utils.Visibility
 import com.google.firebase.Timestamp
 import java.security.MessageDigest
 
+/**
+ * Represents a note stored in the database.
+ *
+ * @property id A unique identifier for this note.
+ * @property title The title of the note.
+ * @property date The timestamp of when the note was created.
+ * @property visibility The visibility setting for the note.
+ * @property noteCourse The [Course] object associated with this note.
+ * @property userId The unique identifier of the user who created the note.
+ * @property folderId The unique identifier of the folder the note is stored in. If the note is not
+ *   assigned to a folder, this value is `null`.
+ * @property comments A collection of comments associated with the note.
+ */
 data class Note(
     val id: String,
     val title: String,
-    val content: String,
     val date: Timestamp,
     val visibility: Visibility = Visibility.DEFAULT,
     val noteCourse: Course,
     val userId: String,
     val folderId: String? = null, // if note not assigned to a folder, folderId is null
-    val image: Bitmap,
     val comments: CommentCollection = CommentCollection()
 ) {
 

--- a/app/src/main/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestore.kt
@@ -1,6 +1,5 @@
 package com.github.onlynotesswent.model.note
 
-import android.graphics.Bitmap
 import android.util.Log
 import com.github.onlynotesswent.utils.Course
 import com.github.onlynotesswent.utils.Visibility
@@ -17,7 +16,6 @@ class NoteRepositoryFirestore(private val db: FirebaseFirestore) : NoteRepositor
   private data class FirebaseNote(
       val id: String,
       val title: String,
-      val content: String,
       val date: Timestamp,
       val visibility: Visibility,
       val userId: String,
@@ -26,7 +24,6 @@ class NoteRepositoryFirestore(private val db: FirebaseFirestore) : NoteRepositor
       val courseYear: Int,
       val publicPath: String,
       val folderId: String?,
-      val image: String,
       val commentsList: List<String>
   )
   /**
@@ -101,7 +98,6 @@ class NoteRepositoryFirestore(private val db: FirebaseFirestore) : NoteRepositor
     return FirebaseNote(
         note.id,
         note.title,
-        note.content,
         note.date,
         note.visibility,
         note.userId,
@@ -110,7 +106,6 @@ class NoteRepositoryFirestore(private val db: FirebaseFirestore) : NoteRepositor
         note.noteCourse.courseYear,
         note.noteCourse.publicPath,
         note.folderId,
-        "null",
         convertCommentsList(note.comments.commentsList))
   }
 
@@ -310,7 +305,6 @@ class NoteRepositoryFirestore(private val db: FirebaseFirestore) : NoteRepositor
     return try {
       val id = document.id
       val title = document.getString("title") ?: ""
-      val content = document.getString("content") ?: ""
       val date = document.getTimestamp("date") ?: Timestamp.now()
       val visibility =
           Visibility.fromString(document.getString("visibility") ?: Visibility.DEFAULT.toString())
@@ -320,11 +314,8 @@ class NoteRepositoryFirestore(private val db: FirebaseFirestore) : NoteRepositor
       val courseYear = document.getLong("courseYear")?.toInt() ?: 0
       val publicPath = document.getString("publicPath") ?: ""
       val folderId = document.getString("folderId")
-      val image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
       val comments =
           commentStringToCommentClass(document.get("commentsList") as? List<String> ?: emptyList())
-      // Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888) is the default bitMap, to be changed
-      // when we implement images by URL
 
       val course =
           if (courseYear == 0 ||
@@ -339,13 +330,11 @@ class NoteRepositoryFirestore(private val db: FirebaseFirestore) : NoteRepositor
       Note(
           id = id,
           title = title,
-          content = content,
           date = date,
           visibility = visibility,
           userId = userId,
           noteCourse = course,
           folderId = folderId,
-          image = image,
           comments = Note.CommentCollection(comments))
     } catch (e: Exception) {
       Log.e(TAG, "Error converting document to Note", e)

--- a/app/src/main/java/com/github/onlynotesswent/model/note/NoteViewModel.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/note/NoteViewModel.kt
@@ -58,7 +58,7 @@ class NoteViewModel(private val repository: NoteRepository) : ViewModel() {
    *
    * @param selectedNote The selected Note document.
    */
-  fun selectedNote(selectedNote: Note) {
+  fun selectedNote(selectedNote: Note?) {
     _selectedNote.value = selectedNote
   }
 

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/AddNote.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/AddNote.kt
@@ -1,6 +1,5 @@
 package com.github.onlynotesswent.ui.overview
 
-import android.graphics.Bitmap
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -242,12 +241,10 @@ fun CreateNoteButton(
             Note(
                 id = noteUid,
                 title = title,
-                content = "",
                 date = Timestamp.now(),
                 visibility = visibility!!,
                 noteCourse = Course(courseCode, courseName, courseYear, "path"),
                 userId = currentUser.value!!.uid,
-                image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888),
                 folderId = folderId)
         noteViewModel.addNote(note, currentUser.value!!.uid)
 

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/EditMarkdownScreen.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/EditMarkdownScreen.kt
@@ -93,7 +93,7 @@ fun EditMarkdownScreen(
   // Function to download and set the Markdown file
   LaunchedEffect(Unit) {
     fileViewModel.downloadFile(
-        uid = selectedNote?.id ?: "errorNoId",
+        uid = selectedNote!!.id,
         fileType = FileType.NOTE_TEXT,
         context = context,
         onSuccess = { downloadedFile: File ->
@@ -135,29 +135,32 @@ fun EditMarkdownScreen(
               Icon(imageVector = Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Back")
             },
             iconTestTag = "goBackButton")
-      },
-      content = { paddingValues ->
-        Column(
-            modifier =
-                Modifier.fillMaxSize()
-                    .padding(16.dp)
-                    .padding(paddingValues)
-                    .testTag("editMarkdownColumn")
-                    .verticalScroll(rememberScrollState()),
-        ) {
-          EditorControls(modifier = Modifier.testTag("EditorControl"), state = state)
-          RichTextEditor(
-              modifier = Modifier.fillMaxWidth().weight(2f).testTag("RichTextEditor"),
-              state = state,
-          )
+      }) { paddingValues ->
+        if (selectedNote == null) {
+          ErrorScreen("No note is selected")
+        } else {
+          Column(
+              modifier =
+                  Modifier.fillMaxSize()
+                      .padding(16.dp)
+                      .padding(paddingValues)
+                      .testTag("editMarkdownColumn")
+                      .verticalScroll(rememberScrollState()),
+          ) {
+            EditorControls(modifier = Modifier.testTag("EditorControl"), state = state)
+            RichTextEditor(
+                modifier = Modifier.fillMaxWidth().weight(2f).testTag("RichTextEditor"),
+                state = state,
+            )
 
-          Button(
-              modifier = Modifier.fillMaxWidth().testTag("Save button"),
-              onClick = { updateMarkdownFile(context, selectedNote?.id ?: "", fileViewModel) }) {
-                Text("Save")
-              }
+            Button(
+                modifier = Modifier.fillMaxWidth().testTag("Save button"),
+                onClick = { updateMarkdownFile(context, selectedNote!!.id, fileViewModel) }) {
+                  Text("Save")
+                }
+          }
         }
-      })
+      }
 }
 /**
  * A composable component that provides a set of text formatting controls for the rich text editor.

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
@@ -281,7 +281,7 @@ fun EditNoteScreen(
                     currentUser = currentUser!!,
                     updatedComments = updatedComments,
                     onCommentsChange = { updatedComments = it },
-                    updateOnlyNoteCommentAndDate = {
+                    updateNoteComment = {
                       noteViewModel.updateNote(
                           note!!.copy(comments = updatedComments), currentUser!!.uid)
                     })
@@ -371,68 +371,6 @@ fun ErrorScreen(errorText: String) {
         Text(errorText)
       }
   Log.e("EditNoteScreen", errorText)
-}
-
-/**
- * Displays the comments section of the edit note screen. The section includes a list of comments
- * with text fields for editing each comment, and buttons for deleting comments and adding new
- * comments.
- *
- * @param updatedComments The collection of comments to be displayed and edited.
- * @param onCommentsChange The callback function to update the comments collection.
- * @param updateOnlyNoteCommentAndDate The callback function to update only the note's comments and
- *   date.
- */
-@Composable
-fun CommentsSection(
-    updatedComments: Note.CommentCollection,
-    onCommentsChange: (Note.CommentCollection) -> Unit,
-    updateOnlyNoteCommentAndDate: () -> Unit
-) {
-  if (updatedComments.commentsList.isEmpty()) {
-    Text(
-        text = "No comments yet. Add a comment to start the discussion.",
-        color = Color.Gray,
-        modifier = Modifier.padding(8.dp).testTag("NoCommentsText"))
-  } else {
-    updatedComments.commentsList.forEachIndexed { _, comment ->
-      Row(
-          modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-          verticalAlignment = Alignment.CenterVertically) {
-            OutlinedTextField(
-                value = comment.content,
-                onValueChange = {
-                  onCommentsChange(updatedComments.editCommentByCommentId(comment.commentId, it))
-                  updateOnlyNoteCommentAndDate()
-                },
-                label = {
-                  val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
-                  val formattedDate = formatter.format(comment.editedDate.toDate())
-                  val displayedText =
-                      if (comment.isUnedited()) {
-                        "${comment.userName} : $formattedDate"
-                      } else {
-                        "${comment.userName} edited: $formattedDate"
-                      }
-                  Text(displayedText)
-                },
-                placeholder = { Text("Enter comment here") },
-                modifier = Modifier.weight(1f).testTag("EditCommentTextField"))
-
-            IconButton(
-                onClick = {
-                  onCommentsChange(updatedComments.deleteCommentByCommentId(comment.commentId))
-                  updateOnlyNoteCommentAndDate()
-                },
-                modifier = Modifier.testTag("DeleteCommentButton")) {
-                  Icon(
-                      imageVector = Icons.Default.Delete,
-                      contentDescription = "Delete Comment",
-                      tint = Color.Red)
-                }
-          }
-    }
-  }
 }
 
 /**
@@ -536,15 +474,14 @@ fun DeleteButton(
  * @param currentUser The current user.
  * @param updatedComments The updated collection of comments for the note.
  * @param onCommentsChange The callback function to update the comments collection.
- * @param updateOnlyNoteCommentAndDate The callback function to update only the note's comments and
- *   date.
+ * @param updateNoteComment The callback function to update the note's comments.
  */
 @Composable
 fun AddCommentButton(
     currentUser: User,
     updatedComments: Note.CommentCollection,
     onCommentsChange: (Note.CommentCollection) -> Unit,
-    updateOnlyNoteCommentAndDate: () -> Unit
+    updateNoteComment: () -> Unit
 ) {
   Button(
       colors =
@@ -554,9 +491,71 @@ fun AddCommentButton(
       onClick = {
         onCommentsChange(
             updatedComments.addCommentByUser(currentUser.uid, currentUser.userName, ""))
-        updateOnlyNoteCommentAndDate()
+        updateNoteComment()
       },
       modifier = Modifier.testTag("Add Comment Button")) {
         Text("Add Comment")
       }
+}
+
+/**
+ * Displays the comments section of the edit note screen. The section includes a list of comments
+ * with text fields for editing each comment, and buttons for deleting comments and adding new
+ * comments.
+ *
+ * @param updatedComments The collection of comments to be displayed and edited.
+ * @param onCommentsChange The callback function to update the comments collection.
+ * @param updateNoteComment The callback function to update only the note's comments and
+ *   date.
+ */
+@Composable
+fun CommentsSection(
+    updatedComments: Note.CommentCollection,
+    onCommentsChange: (Note.CommentCollection) -> Unit,
+    updateNoteComment: () -> Unit
+) {
+    if (updatedComments.commentsList.isEmpty()) {
+        Text(
+            text = "No comments yet. Add a comment to start the discussion.",
+            color = Color.Gray,
+            modifier = Modifier.padding(8.dp).testTag("NoCommentsText"))
+    } else {
+        updatedComments.commentsList.forEachIndexed { _, comment ->
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically) {
+                OutlinedTextField(
+                    value = comment.content,
+                    onValueChange = {
+                        onCommentsChange(updatedComments.editCommentByCommentId(comment.commentId, it))
+                        updateNoteComment()
+                    },
+                    label = {
+                        val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+                        val formattedDate = formatter.format(comment.editedDate.toDate())
+                        val displayedText =
+                            if (comment.isUnedited()) {
+                                "${comment.userName} : $formattedDate"
+                            } else {
+                                "${comment.userName} edited: $formattedDate"
+                            }
+                        Text(displayedText)
+                    },
+                    placeholder = { Text("Enter comment here") },
+                    modifier = Modifier.weight(1f).testTag("EditCommentTextField"))
+
+                IconButton(
+                    onClick = {
+                        onCommentsChange(updatedComments.deleteCommentByCommentId(comment.commentId))
+                        updateNoteComment()
+                    },
+                    modifier = Modifier.testTag("DeleteCommentButton")) {
+                    Icon(
+                        imageVector = Icons.Default.Delete,
+                        contentDescription = "Delete Comment",
+                        tint = Color.Red)
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
@@ -1,6 +1,5 @@
 package com.github.onlynotesswent.ui.overview
 
-import android.graphics.Bitmap
 import android.net.Uri
 import android.util.Log
 import android.widget.Toast
@@ -89,7 +88,6 @@ fun EditNoteScreen(
   val note by noteViewModel.selectedNote.collectAsState()
   val currentUser by userViewModel.currentUser.collectAsState()
   val currentYear = Calendar.getInstance().get(Calendar.YEAR)
-  val noteText by remember { mutableStateOf(note?.content ?: "") }
   var noteTitle by remember { mutableStateOf(note?.title ?: "") }
   var courseName by remember { mutableStateOf(note?.noteCourse?.courseName ?: "") }
   var courseCode by remember { mutableStateOf(note?.noteCourse?.courseCode ?: "") }
@@ -142,15 +140,11 @@ fun EditNoteScreen(
         Note(
             id = note?.id ?: "1",
             title = note?.title ?: "",
-            content = note?.content ?: "",
             date = Timestamp.now(), // Use current timestamp
             visibility = note?.visibility ?: Visibility.DEFAULT,
             noteCourse = note?.noteCourse ?: Course.DEFAULT,
             userId = note?.userId ?: "",
             folderId = note?.folderId,
-            image =
-                note?.image
-                    ?: Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888), // Placeholder Bitmap
             comments = updatedComments),
         currentUser!!.uid)
   }
@@ -279,7 +273,6 @@ fun EditNoteScreen(
                 SaveButton(
                     noteTitle = noteTitle,
                     note = note,
-                    updatedNoteText = noteText,
                     visibility = visibility,
                     courseCode = courseCode,
                     courseName = courseName,
@@ -448,7 +441,6 @@ fun CommentsSection(
  *
  * @param noteTitle The updated title of the note.
  * @param note The note to be updated.
- * @param updatedNoteText The updated content of the note.
  * @param visibility The updated visibility of the note.
  * @param courseCode The updated course code of the note.
  * @param courseName The updated course name of the note.
@@ -463,7 +455,6 @@ fun CommentsSection(
 fun SaveButton(
     noteTitle: String,
     note: Note?,
-    updatedNoteText: String,
     visibility: Visibility?,
     courseCode: String,
     courseName: String,
@@ -480,15 +471,11 @@ fun SaveButton(
             Note(
                 id = note?.id ?: "1",
                 title = noteTitle,
-                content = updatedNoteText,
                 date = Timestamp.now(), // Use current timestamp
                 visibility = visibility ?: Visibility.DEFAULT,
                 noteCourse = Course(courseCode, courseName, courseYear, "path"),
                 userId = note?.userId ?: currentUser!!.uid,
                 folderId = note?.folderId,
-                image =
-                    note?.image
-                        ?: Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888), // Placeholder Bitmap
                 comments = updatedComments),
             currentUser!!.uid)
         if (note?.folderId != null) {

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
@@ -505,8 +505,7 @@ fun AddCommentButton(
  *
  * @param updatedComments The collection of comments to be displayed and edited.
  * @param onCommentsChange The callback function to update the comments collection.
- * @param updateNoteComment The callback function to update only the note's comments and
- *   date.
+ * @param updateNoteComment The callback function to update only the note's comments and date.
  */
 @Composable
 fun CommentsSection(
@@ -514,48 +513,48 @@ fun CommentsSection(
     onCommentsChange: (Note.CommentCollection) -> Unit,
     updateNoteComment: () -> Unit
 ) {
-    if (updatedComments.commentsList.isEmpty()) {
-        Text(
-            text = "No comments yet. Add a comment to start the discussion.",
-            color = Color.Gray,
-            modifier = Modifier.padding(8.dp).testTag("NoCommentsText"))
-    } else {
-        updatedComments.commentsList.forEachIndexed { _, comment ->
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-                verticalAlignment = Alignment.CenterVertically) {
-                OutlinedTextField(
-                    value = comment.content,
-                    onValueChange = {
-                        onCommentsChange(updatedComments.editCommentByCommentId(comment.commentId, it))
-                        updateNoteComment()
-                    },
-                    label = {
-                        val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
-                        val formattedDate = formatter.format(comment.editedDate.toDate())
-                        val displayedText =
-                            if (comment.isUnedited()) {
-                                "${comment.userName} : $formattedDate"
-                            } else {
-                                "${comment.userName} edited: $formattedDate"
-                            }
-                        Text(displayedText)
-                    },
-                    placeholder = { Text("Enter comment here") },
-                    modifier = Modifier.weight(1f).testTag("EditCommentTextField"))
+  if (updatedComments.commentsList.isEmpty()) {
+    Text(
+        text = "No comments yet. Add a comment to start the discussion.",
+        color = Color.Gray,
+        modifier = Modifier.padding(8.dp).testTag("NoCommentsText"))
+  } else {
+    updatedComments.commentsList.forEachIndexed { _, comment ->
+      Row(
+          modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+          verticalAlignment = Alignment.CenterVertically) {
+            OutlinedTextField(
+                value = comment.content,
+                onValueChange = {
+                  onCommentsChange(updatedComments.editCommentByCommentId(comment.commentId, it))
+                  updateNoteComment()
+                },
+                label = {
+                  val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+                  val formattedDate = formatter.format(comment.editedDate.toDate())
+                  val displayedText =
+                      if (comment.isUnedited()) {
+                        "${comment.userName} : $formattedDate"
+                      } else {
+                        "${comment.userName} edited: $formattedDate"
+                      }
+                  Text(displayedText)
+                },
+                placeholder = { Text("Enter comment here") },
+                modifier = Modifier.weight(1f).testTag("EditCommentTextField"))
 
-                IconButton(
-                    onClick = {
-                        onCommentsChange(updatedComments.deleteCommentByCommentId(comment.commentId))
-                        updateNoteComment()
-                    },
-                    modifier = Modifier.testTag("DeleteCommentButton")) {
-                    Icon(
-                        imageVector = Icons.Default.Delete,
-                        contentDescription = "Delete Comment",
-                        tint = Color.Red)
+            IconButton(
+                onClick = {
+                  onCommentsChange(updatedComments.deleteCommentByCommentId(comment.commentId))
+                  updateNoteComment()
+                },
+                modifier = Modifier.testTag("DeleteCommentButton")) {
+                  Icon(
+                      imageVector = Icons.Default.Delete,
+                      contentDescription = "Delete Comment",
+                      tint = Color.Red)
                 }
-            }
-        }
+          }
     }
+  }
 }

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
@@ -142,9 +142,9 @@ fun EditNoteScreen(
             title = "Edit note",
             titleTestTag = "editNoteTitle",
             onBackClick = {
-                //Unselects the note and navigates back to the previous screen
-                noteViewModel.selectedNote(null)
-                navigationActions.goBack()
+              // Unselects the note and navigates back to the previous screen
+              noteViewModel.selectedNote(null)
+              navigationActions.goBack()
             },
             icon = {
               Icon(
@@ -480,10 +480,10 @@ fun SaveButton(
                 comments = updatedComments),
             currentUser.uid)
         if (note.folderId != null) {
-            noteViewModel.selectedNote(null)
+          noteViewModel.selectedNote(null)
           navigationActions.navigateTo(Screen.FOLDER_CONTENTS)
         } else {
-            noteViewModel.selectedNote(null)
+          noteViewModel.selectedNote(null)
           navigationActions.navigateTo(TopLevelDestinations.OVERVIEW)
         }
       },
@@ -521,7 +521,7 @@ fun DeleteButton(
       border = BorderStroke(1.dp, MaterialTheme.colorScheme.error),
       onClick = {
         noteViewModel.deleteNoteById(note.id, note.userId)
-          noteViewModel.selectedNote(null)
+        noteViewModel.selectedNote(null)
         navigationActions.navigateTo(Screen.OVERVIEW)
       },
       modifier = Modifier.testTag("Delete button")) {

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/EditNote.kt
@@ -141,7 +141,11 @@ fun EditNoteScreen(
         ScreenTopBar(
             title = "Edit note",
             titleTestTag = "editNoteTitle",
-            onBackClick = { navigationActions.goBack() },
+            onBackClick = {
+                //Unselects the note and navigates back to the previous screen
+                noteViewModel.selectedNote(null)
+                navigationActions.goBack()
+            },
             icon = {
               Icon(
                   imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
@@ -476,8 +480,10 @@ fun SaveButton(
                 comments = updatedComments),
             currentUser.uid)
         if (note.folderId != null) {
+            noteViewModel.selectedNote(null)
           navigationActions.navigateTo(Screen.FOLDER_CONTENTS)
         } else {
+            noteViewModel.selectedNote(null)
           navigationActions.navigateTo(TopLevelDestinations.OVERVIEW)
         }
       },
@@ -515,6 +521,7 @@ fun DeleteButton(
       border = BorderStroke(1.dp, MaterialTheme.colorScheme.error),
       onClick = {
         noteViewModel.deleteNoteById(note.id, note.userId)
+          noteViewModel.selectedNote(null)
         navigationActions.navigateTo(Screen.OVERVIEW)
       },
       modifier = Modifier.testTag("Delete button")) {

--- a/app/src/test/java/com/github/onlynotesswent/model/authentication/GoogleCredSignInTest.kt
+++ b/app/src/test/java/com/github/onlynotesswent/model/authentication/GoogleCredSignInTest.kt
@@ -16,8 +16,6 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mock
-import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
@@ -26,14 +24,11 @@ import org.robolectric.shadows.ShadowLog
 
 @RunWith(RobolectricTestRunner::class)
 class GoogleCredSignInTest {
-  private fun <T> any(type: Class<T>): T = Mockito.any(type)
-
   private val context = mock(Context::class.java)
   private val credentialManager = mock(CredentialManager::class.java)
   private val launcher =
       mock(ManagedActivityResultLauncher::class.java)
           as ManagedActivityResultLauncher<Intent, ActivityResult>
-  @Mock private lateinit var mockCoroutineScope: TestScope
   private val serverClientId = "test-server-client-id"
   private lateinit var googleCredSignIn: GoogleCredSignIn
 
@@ -93,7 +88,6 @@ class GoogleCredSignInTest {
   fun `handleSignIn should log error when unexpected type`() {
     runTest {
       val mockGetCredentialResponse = mock(GetCredentialResponse::class.java)
-      val mockCustomCredential = mock(CustomCredential::class.java)
 
       `when`(credentialManager.getCredential(any(), any<GetCredentialRequest>()))
           .thenReturn(mockGetCredentialResponse)
@@ -101,86 +95,6 @@ class GoogleCredSignInTest {
       googleCredSignIn.googleLogin {}
     }
   }
-
-  //    @Test
-  //    fun `googleLogin getCredential fails`() {
-  //        runTest {
-  //            val mockGetCredentialResponse = mock(GetCredentialResponse::class.java)
-  //            val mockCustomCredential = mock(CustomCredential::class.java)
-  //            val mockException = mock(GetCredentialException::class.java)
-  //
-  //            `when`(credentialManager.getCredential(any(),
-  // any<GetCredentialRequest>())).thenThrow(
-  //                RuntimeException("Error getting credential")
-  //            )
-  //
-  //            googleCredSignIn.googleLogin { }
-  //
-  //            // Get all the logs
-  //            val logs = ShadowLog.getLogs()
-  //
-  //            // Check for the debug log that should be generated
-  //            val errorLog =
-  //                logs.find {
-  //                    it.type == Log.ERROR &&
-  //                            it.tag == "GoogleCredSignIn" &&
-  //                            it.msg == "Error getting credential"
-  //                }
-  //            assert(errorLog != null) { "Expected error log was not found!" }
-  //
-  //        }
-  //    }
-  //
-  //        val mockCallback = mock<(String) -> Unit>()
-  //        val mockGetCredentialResponse = mock(GetCredentialResponse::class.java)
-  //        val mockCustomCredential = mock(CustomCredential::class.java)
-  //
-  //        `when`(mockGetCredentialResponse.credential).thenReturn(mockCustomCredential)
-  //        //`when`(mockCustomCredential is CustomCredential).thenReturn(true)
-  //
-  // `when`(mockCustomCredential.type).thenReturn(GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL)
-  //        `when`(mockCustomCredential.data).thenReturn(Bundle())
-  //
-  //        googleCredSignIn.handleSignIn(mockCallback, mockGetCredentialResponse)
-  //
-  //        verify(mockCallback).invoke(any())
-  //
-  //        GoogleIdTokenCredentialMock.close()
-
-  //        val CoroutineScopeMock = Mockito.mockStatic(CoroutineScope::class.java)
-  //        CoroutineScopeMock.`when`<CoroutineScope> { CoroutineScope(Dispatchers.IO)
-  // }.thenReturn(mockCoroutineScope)
-  //
-  //        runTest {
-  //            val mockGetCredentialResponse = mock(GetCredentialResponse::class.java)
-  //            val mockCustomCredential = mock(CustomCredential::class.java)
-  //
-  //            `when`(credentialManager.getCredential(any(),
-  // any<GetCredentialRequest>())).thenReturn(mockGetCredentialResponse)
-  //            `when`(mockGetCredentialResponse.credential).thenReturn(mockCustomCredential)
-  //
-  //            googleCredSignIn.googleLogin {  }
-  //
-  //        }
-  //
-  //        // Arrange
-  //        val invalidCredential = CustomCredential(
-  //            "invalid_type",
-  //            Bundle()
-  //        )
-  //
-  //        val CoroutineScopeMock = Mockito.mockStatic(CoroutineScope::class.java)
-  //        CoroutineScopeMock.`when`<CoroutineScope> { CoroutineScope(Dispatchers.IO)
-  // }.thenReturn(mockCoroutineScope)
-  //
-  //        mockCoroutineScope.launch {
-  //            val mockGetCredentialResponse = mock(GetCredentialResponse::class.java)
-  //            val mockCustomCredential = mock(CustomCredential::class.java)
-  //            `when`(credentialManager.getCredential(any(),
-  // any<GetCredentialRequest>())).thenReturn(mockGetCredentialResponse)
-  //            `when`(mockGetCredentialResponse.credential).thenReturn(mockCustomCredential)
-  //        }
-  //     }
 
   @Test
   fun `generateNonce should generate a hashed nonce`() {

--- a/app/src/test/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestoreTest.kt
@@ -1,6 +1,5 @@
 package com.github.onlynotesswent.model.note
 
-import android.graphics.Bitmap
 import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import com.github.onlynotesswent.utils.Course
@@ -48,12 +47,10 @@ class NoteRepositoryFirestoreTest {
       Note(
           id = "1",
           title = "title",
-          content = "content",
           date = Timestamp.now(),
           visibility = Visibility.PUBLIC,
           userId = "1",
           noteCourse = Course("CS-100", "Sample Course", 2024, "path"),
-          image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888),
           comments =
               Note.CommentCollection(
                   listOf(Note.Comment("1", "1", "bob", "1", Timestamp.now(), Timestamp.now()))))
@@ -61,12 +58,10 @@ class NoteRepositoryFirestoreTest {
       Note(
           id = "2",
           title = "title",
-          content = "content",
           date = Timestamp.now(),
           visibility = Visibility.PRIVATE,
           userId = "1",
           noteCourse = Course("CS-100", "Sample Course", 2024, "path"),
-          image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888),
           comments =
               Note.CommentCollection(
                   listOf(Note.Comment("1", "1", "bob", "1", Timestamp.now(), Timestamp.now()))))
@@ -75,25 +70,22 @@ class NoteRepositoryFirestoreTest {
       Note(
           id = "1",
           title = "title",
-          content = "content",
           date = Timestamp.now(),
           visibility = Visibility.PUBLIC,
           userId = "1",
           folderId = "1",
           noteCourse = Course("CS-100", "Sample Course", 2024, "path"),
-          image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
+      )
 
   private val testSubNotePrivate =
       Note(
           id = "1",
           title = "title",
-          content = "content",
           date = Timestamp.now(),
           visibility = Visibility.PRIVATE,
           userId = "1",
           folderId = "1",
           noteCourse = Course("CS-100", "Sample Course", 2024, "path"),
-          image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888),
           comments =
               Note.CommentCollection(
                   listOf(Note.Comment("1", "1", "bob", "1", Timestamp.now(), Timestamp.now()))))
@@ -133,7 +125,6 @@ class NoteRepositoryFirestoreTest {
 
     `when`(mockDocumentSnapshot.id).thenReturn(testNotePublic.id)
     `when`(mockDocumentSnapshot.getString("title")).thenReturn(testNotePublic.title)
-    `when`(mockDocumentSnapshot.getString("content")).thenReturn(testNotePublic.content)
     `when`(mockDocumentSnapshot.getTimestamp("date")).thenReturn(testNotePublic.date)
     `when`(mockDocumentSnapshot.getString("visibility"))
         .thenReturn(testNotePublic.visibility.toString())
@@ -146,11 +137,9 @@ class NoteRepositoryFirestoreTest {
     `when`(mockDocumentSnapshot.getString("publicPath"))
         .thenReturn(testNotePublic.noteCourse.publicPath)
     `when`(mockDocumentSnapshot.getString("userId")).thenReturn(testNotePublic.userId)
-    `when`(mockDocumentSnapshot.get("image")).thenReturn(testNotePublic.image)
 
     `when`(mockDocumentSnapshot2.id).thenReturn(testNotePrivate.id)
     `when`(mockDocumentSnapshot2.getString("title")).thenReturn(testNotePrivate.title)
-    `when`(mockDocumentSnapshot2.getString("content")).thenReturn(testNotePrivate.content)
     `when`(mockDocumentSnapshot2.getTimestamp("date")).thenReturn(testNotePrivate.date)
     `when`(mockDocumentSnapshot2.getString("visibility"))
         .thenReturn(testNotePrivate.visibility.toString())
@@ -163,12 +152,10 @@ class NoteRepositoryFirestoreTest {
     `when`(mockDocumentSnapshot.getString("publicPath"))
         .thenReturn(testNotePrivate.noteCourse.publicPath)
     `when`(mockDocumentSnapshot2.getString("userId")).thenReturn(testNotePrivate.userId)
-    `when`(mockDocumentSnapshot2.get("image")).thenReturn(testNotePrivate.image)
     `when`(mockDocumentSnapshot2.get("commentsList")).thenReturn(testNotePrivate.comments)
 
     `when`(mockDocumentSnapshot3.id).thenReturn(testSubNotePublic.id)
     `when`(mockDocumentSnapshot3.getString("title")).thenReturn(testSubNotePublic.title)
-    `when`(mockDocumentSnapshot3.getString("content")).thenReturn(testSubNotePublic.content)
     `when`(mockDocumentSnapshot3.getTimestamp("date")).thenReturn(testSubNotePublic.date)
     `when`(mockDocumentSnapshot3.getString("visibility"))
         .thenReturn(testSubNotePublic.visibility.toString())
@@ -182,11 +169,9 @@ class NoteRepositoryFirestoreTest {
         .thenReturn(testSubNotePublic.noteCourse.publicPath)
     `when`(mockDocumentSnapshot3.getString("userId")).thenReturn(testSubNotePublic.userId)
     `when`(mockDocumentSnapshot3.getString("folderId")).thenReturn(testSubNotePublic.folderId)
-    `when`(mockDocumentSnapshot3.get("image")).thenReturn(testSubNotePublic.image)
 
     `when`(mockDocumentSnapshot4.id).thenReturn(testSubNotePrivate.id)
     `when`(mockDocumentSnapshot4.getString("title")).thenReturn(testSubNotePrivate.title)
-    `when`(mockDocumentSnapshot4.getString("content")).thenReturn(testSubNotePrivate.content)
     `when`(mockDocumentSnapshot4.getTimestamp("date")).thenReturn(testSubNotePrivate.date)
     `when`(mockDocumentSnapshot4.getString("visibility"))
         .thenReturn(testSubNotePrivate.visibility.toString())
@@ -200,13 +185,11 @@ class NoteRepositoryFirestoreTest {
         .thenReturn(testSubNotePrivate.noteCourse.publicPath)
     `when`(mockDocumentSnapshot4.getString("userId")).thenReturn(testSubNotePrivate.userId)
     `when`(mockDocumentSnapshot4.getString("folderId")).thenReturn(testSubNotePrivate.folderId)
-    `when`(mockDocumentSnapshot4.get("image")).thenReturn(testSubNotePrivate.image)
   }
 
   private fun compareNotesButNotImage(note1: Note, note2: Note) {
     assert(note1.id == note2.id)
     assert(note1.title == note2.title)
-    assert(note1.content == note2.content)
     assert(note1.date == note2.date)
     assert(note1.visibility == note2.visibility)
     assert(note1.userId == note2.userId)

--- a/app/src/test/java/com/github/onlynotesswent/model/note/NoteViewModelTest.kt
+++ b/app/src/test/java/com/github/onlynotesswent/model/note/NoteViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.github.onlynotesswent.model.note
 
-import android.graphics.Bitmap
 import com.github.onlynotesswent.utils.Course
 import com.github.onlynotesswent.utils.Visibility
 import com.google.firebase.Timestamp
@@ -25,13 +24,12 @@ class NoteViewModelTest {
       Note(
           id = "1",
           title = "title",
-          content = "content",
           date = Timestamp.now(),
           visibility = Visibility.DEFAULT,
           userId = "1",
           folderId = "1",
           noteCourse = Course("CS-100", "Sample Course", 2024, "path"),
-          image = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
+      )
 
   @Before
   fun setUp() {

--- a/app/src/test/java/com/github/onlynotesswent/utils/NotesToFlashcardTest.kt
+++ b/app/src/test/java/com/github/onlynotesswent/utils/NotesToFlashcardTest.kt
@@ -20,7 +20,6 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
 import org.mockito.Captor
 import org.mockito.Mock
-import org.mockito.Mockito
 import org.mockito.Mockito.anyString
 import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.times
@@ -28,14 +27,12 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class NotesToFlashcardTest {
-  // Function to allow null arguments for Mockito when needed
-  private fun <T> nullableAny(): T = Mockito.any()
-
   // Helper function to capture arguments in Mockito tests, bypassing Kotlin's null-safety checks
   private fun <T> capture(argumentCaptor: ArgumentCaptor<T>): T = argumentCaptor.capture()
 
@@ -84,8 +81,6 @@ class NotesToFlashcardTest {
   @Mock private lateinit var mockOpenAI: OpenAI
 
   @Mock private lateinit var mockContext: Context
-
-  @Mock private lateinit var mockMd: File
 
   // Argument captor for Flashcard objects
   @Captor private lateinit var flashcardCaptor: ArgumentCaptor<Flashcard>
@@ -176,7 +171,7 @@ class NotesToFlashcardTest {
           null
         }
         .`when`(mockOpenAI)
-        .sendRequest(anyString(), nullableAny(), nullableAny(), anyString())
+        .sendRequest(anyString(), anyOrNull(), anyOrNull(), anyString())
 
     // Set up a flag to ensure the failure callback was called
     var failureCallbackCalled = false
@@ -205,7 +200,7 @@ class NotesToFlashcardTest {
           null
         }
         .`when`(mockOpenAI)
-        .sendRequest(anyString(), nullableAny(), nullableAny(), anyString())
+        .sendRequest(anyString(), anyOrNull(), anyOrNull(), anyString())
 
     // Set up a flag to ensure the failure callback was called
     var failureCallbackCalled = false


### PR DESCRIPTION
# Description

Removed unused `content` and `image` attributes from note. For this, I also updated NotesToFlashcard to use the markdown file instead of note content and fixed the tests to work with this new method.

Apart from this, I refactor EditNote and EditMarkdown. Currently, we don't check if the selected note is null when we are editing it or its markdown. Instead, we give default values to the functions that need it, so in case of error where no note is selected (which should not happen) we won't know what's wrong, or even detect an error.

Instead of this, I proposed showing an error screen if this unexpected error should happen, which allows the user to go back (like what is done if no user is found in EditNoteScreen), and then if not then we assume (`!!`) that selected note is correct (we still need to use !! since `note` / `selectedNote` is an externally mutable variable so can smart-cast).

I also implemented other smaller style changes (documentation, remove unnecessary comments, etc...), to improve code readability and future maintenance.


Fixes #156

# How Has This Been Tested?

Fixed existing tests to work with new refactored code

  
# Dependencies

No new dependencies


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged in downstream modules, no conflicts with main
