### PR TITLE
Revert: change back flashcards to single data class with new fields

### DIFF
--- a/app/src/main/java/com/github/onlynotesswent/model/flashcard/Flashcard.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/flashcard/Flashcard.kt
@@ -8,178 +8,23 @@ import com.google.firebase.Timestamp
  * @property id The ID of the flashcard.
  * @property front The front side of the flashcard which contains the question.
  * @property back The back side of the flashcard which contains the answer.
+ * @property latexFormula The latex formula for the flashcard, if any.
+ * @property hasImage A flag indicating if the flashcard has an image.
+ * @property fakeBacks The fake backs of the flashcard for MCQs, if any.
  * @property lastReviewed The timestamp of the last review of the flashcard.
  * @property userId The ID of the user who created the flashcard.
  * @property folderId The ID of the folder that the flashcard belongs to.
  * @property noteId The ID of the note that the flashcard belongs to.
- * @property type The type of the flashcard.
  */
-abstract class Flashcard(
-    open val id: String,
-    open val front: String, // The front side of the flashcard which contains the question.
-    open val back: String, // The back side of the flashcard which contains the answer.
-    open val lastReviewed: Timestamp?,
-    open val userId: String,
-    open val folderId: String?,
-    open val noteId: String?,
-    open val type: Type
-) {
-  /** The type of the flashcard. */
-  enum class Type {
-    TEXT,
-    IMAGE,
-    MCQ;
-
-    companion object {
-      /**
-       * Converts the given string to a [Type].
-       *
-       * @param type The string to convert.
-       * @return The [Type] corresponding to the given string.
-       * @throws IllegalArgumentException If the given string does not correspond to a [Type].
-       */
-      fun fromString(type: String): Type {
-        return when (type) {
-          TEXT.toString() -> TEXT
-          IMAGE.toString() -> IMAGE
-          MCQ.toString() -> MCQ
-          else -> throw IllegalArgumentException("Invalid flashcard type")
-        }
-      }
-    }
-  }
-
-  /** Converts the flashcard to a map. */
-  abstract fun toMap(): Map<String, Any?>
-
-  companion object {
-    /**
-     * Creates a flashcard from the given type and map.
-     *
-     * @param type The type of the flashcard.
-     * @param map The map containing the flashcard data.
-     * @return The flashcard created from the given type and map.
-     * @throws IllegalArgumentException If the map does not contain valid flashcard data.
-     */
-    fun from(type: Type, map: Map<String, Any?>): Flashcard {
-      return try {
-        when (type) {
-          Type.TEXT ->
-              TextFlashcard(
-                  map["id"] as String,
-                  map["front"] as String,
-                  map["back"] as String,
-                  map["lastReviewed"] as Timestamp?,
-                  map["userId"] as String,
-                  map["folderId"] as String?,
-                  map["noteId"] as String?)
-          Type.IMAGE ->
-              ImageFlashcard(
-                  map["id"] as String,
-                  map["front"] as String,
-                  map["back"] as String,
-                  map["imageUrl"] as String,
-                  map["lastReviewed"] as Timestamp?,
-                  map["userId"] as String,
-                  map["folderId"] as String?,
-                  map["noteId"] as String?)
-          Type.MCQ ->
-              MCQFlashcard(
-                  map["id"] as String,
-                  map["front"] as String,
-                  map["back"] as String,
-                  map["fakeBacks"] as List<String>,
-                  map["lastReviewed"] as Timestamp?,
-                  map["userId"] as String,
-                  map["folderId"] as String?,
-                  map["noteId"] as String?)
-        }
-      } catch (e: Exception) {
-        throw IllegalArgumentException("Invalid flashcard data")
-      }
-    }
-  }
-}
-
-/** Represents a text flashcard. */
-data class TextFlashcard(
-    override val id: String,
-    override val front: String,
-    override val back: String,
-    override val lastReviewed: Timestamp?,
-    override val userId: String,
-    override val folderId: String?,
-    override val noteId: String?
-) : Flashcard(id, front, back, lastReviewed, userId, folderId, noteId, Type.TEXT) {
-  override fun toMap(): Map<String, Any?> {
-    return mapOf(
-        "id" to id,
-        "front" to front,
-        "back" to back,
-        "lastReviewed" to lastReviewed,
-        "userId" to userId,
-        "folderId" to folderId,
-        "noteId" to noteId,
-        "type" to type.toString())
-  }
-}
-
-/**
- * Represents an image flashcard.
- *
- * @property imageUrl The URL of the image.
- */
-data class ImageFlashcard(
-    override val id: String,
-    override val front: String,
-    override val back: String,
-    val imageUrl: String,
-    override val lastReviewed: Timestamp?,
-    override val userId: String,
-    override val folderId: String?,
-    override val noteId: String?
-) : Flashcard(id, front, back, lastReviewed, userId, folderId, noteId, Type.IMAGE) {
-  override fun toMap(): Map<String, Any?> {
-    return mapOf(
-        "id" to id,
-        "front" to front,
-        "back" to back,
-        "imageUrl" to imageUrl,
-        "lastReviewed" to lastReviewed,
-        "userId" to userId,
-        "folderId" to folderId,
-        "noteId" to noteId,
-        "type" to type.toString())
-  }
-}
-
-/**
- * Represents a multiple-choice question flashcard.
- *
- * @property fakeBacks The fake answers that are displayed when the user is reviewing the flashcard.
- *   The correct answer is stored in the [back] property. NB: the [fakeBacks] list can contain more
- *   fake answers than the number of choices displayed to the user.
- */
-data class MCQFlashcard(
-    override val id: String,
-    override val front: String,
-    override val back: String,
-    val fakeBacks: List<String>, // The fake answers that are displayed for MCQ flashcards
-    override val lastReviewed: Timestamp?,
-    override val userId: String,
-    override val folderId: String?,
-    override val noteId: String?,
-) : Flashcard(id, front, back, lastReviewed, userId, folderId, noteId, Type.MCQ) {
-  override fun toMap(): Map<String, Any?> {
-    return mapOf(
-        "id" to id,
-        "front" to front,
-        "back" to back,
-        "fakeBacks" to fakeBacks,
-        "lastReviewed" to lastReviewed,
-        "userId" to userId,
-        "folderId" to folderId,
-        "noteId" to noteId,
-        "type" to type.toString())
-  }
-}
+data class Flashcard(
+    val id: String,
+    val front: String, // The front side of the flashcard which contains the question.
+    val back: String, // The back side of the flashcard which contains the answer.
+    val latexFormula: String = "", // The latex formula for the flashcard, if any.
+    val hasImage: Boolean = false, // A flag indicating if the flashcard has an image.
+    val fakeBacks: List<String> = emptyList(), // The fake backs of the flashcard for MCQs, if any.
+    val lastReviewed: Timestamp?,
+    val userId: String,
+    val folderId: String?,
+    val noteId: String?
+)

--- a/app/src/main/java/com/github/onlynotesswent/model/flashcard/FlashcardRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/flashcard/FlashcardRepositoryFirestore.kt
@@ -23,10 +23,18 @@ class FlashcardRepositoryFirestore(private val db: FirebaseFirestore) : Flashcar
    */
   fun documentSnapshotToFlashcard(document: DocumentSnapshot): Flashcard? {
     return try {
-      val type =
-          Flashcard.Type.fromString(
-              document.getString("type") ?: throw Exception("Invalid flashcard type"))
-      Flashcard.from(type, document.data!!)
+      Flashcard(
+          id = document.id,
+          front = document.getString("front") ?: throw Exception("Front is null"),
+          back = document.getString("back") ?: throw Exception("Back is null"),
+          latexFormula =
+              document.getString("latexFormula") ?: throw Exception("Latex formula is null"),
+          hasImage = document.getBoolean("hasImage") ?: throw Exception("hasImage is null"),
+          fakeBacks = document.get("fakeBacks") as List<String>,
+          lastReviewed = document.getTimestamp("lastReviewed"),
+          userId = document.getString("userId") ?: throw Exception("User ID is null"),
+          folderId = document.getString("folderId"),
+          noteId = document.getString("noteId"))
     } catch (e: Exception) {
       Log.e(TAG, "Error converting document to Flashcard", e)
       null
@@ -125,7 +133,7 @@ class FlashcardRepositoryFirestore(private val db: FirebaseFirestore) : Flashcar
   ) {
     db.collection(collectionPath)
         .document(flashcard.id)
-        .set(flashcard.toMap())
+        .set(flashcard)
         .addOnSuccessListener { onSuccess() }
         .addOnFailureListener { exception ->
           onFailure(exception)
@@ -140,7 +148,7 @@ class FlashcardRepositoryFirestore(private val db: FirebaseFirestore) : Flashcar
   ) {
     db.collection(collectionPath)
         .document(flashcard.id)
-        .set(flashcard.toMap())
+        .set(flashcard)
         .addOnSuccessListener { onSuccess() }
         .addOnFailureListener { exception ->
           onFailure(exception)

--- a/app/src/main/java/com/github/onlynotesswent/utils/NotesToFlashcard.kt
+++ b/app/src/main/java/com/github/onlynotesswent/utils/NotesToFlashcard.kt
@@ -6,9 +6,7 @@ import com.github.onlynotesswent.model.file.FileType
 import com.github.onlynotesswent.model.file.FileViewModel
 import com.github.onlynotesswent.model.flashcard.Flashcard
 import com.github.onlynotesswent.model.flashcard.FlashcardViewModel
-import com.github.onlynotesswent.model.flashcard.TextFlashcard
 import com.github.onlynotesswent.model.note.Note
-import com.google.firebase.Timestamp
 import com.google.gson.JsonParser
 
 class NotesToFlashcard(
@@ -78,13 +76,13 @@ class NotesToFlashcard(
           val answer = flashcardObject.get("answer").asString
 
           val flashcard =
-              TextFlashcard(
+              Flashcard(
                   id = flashcardViewModel.getNewUid(),
                   front = question,
                   back = answer,
-                  lastReviewed = Timestamp.now(),
+                  lastReviewed = null,
                   userId = note.userId,
-                  folderId = note.folderId ?: "",
+                  folderId = note.folderId,
                   noteId = note.id)
           flashcards.add(flashcard)
           flashcardViewModel.addFlashcard(flashcard)

--- a/app/src/test/java/com/github/onlynotesswent/model/flashcard/FlashcardRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/onlynotesswent/model/flashcard/FlashcardRepositoryFirestoreTest.kt
@@ -45,38 +45,17 @@ class FlashcardRepositoryFirestoreTest {
 
   private lateinit var flashcardRepositoryFirestore: FlashcardRepositoryFirestore
 
-  private val textFlashcard =
-      TextFlashcard(
+  private val flashcard =
+      Flashcard(
           id = "1",
           front = "front",
           back = "back",
-          lastReviewed = Timestamp.now(),
-          userId = "2",
-          folderId = "3",
-          noteId = "4")
-
-  private val imageFlashcard =
-      ImageFlashcard(
-          id = "1",
-          front = "front",
-          back = "back",
-          lastReviewed = Timestamp.now(),
-          userId = "2",
-          folderId = "3",
-          noteId = "4",
-          imageUrl = "https://example.com/image.jpg")
-
-  private val mcqFlashcard =
-      MCQFlashcard(
-          id = "1",
-          front = "front",
-          back = "back",
+          hasImage = false,
           fakeBacks = listOf("fake1", "fake2", "fake3"),
           lastReviewed = Timestamp.now(),
           userId = "2",
           folderId = "3",
-          noteId = "4",
-      )
+          noteId = "4")
 
   @Before
   fun setUp() {
@@ -123,19 +102,16 @@ class FlashcardRepositoryFirestoreTest {
 
     // Mock the DocumentSnapshot to return expected fields for a Flashcard
     `when`(mockDocumentSnapshot.exists()).thenReturn(true)
-    `when`(mockDocumentSnapshot.id).thenReturn(textFlashcard.id)
-    `when`(mockDocumentSnapshot.getString("type")).thenReturn(Flashcard.Type.TEXT.toString())
-    `when`(mockDocumentSnapshot.data)
-        .thenReturn(
-            mapOf(
-                "id" to textFlashcard.id,
-                "front" to textFlashcard.front,
-                "back" to textFlashcard.back,
-                "lastReviewed" to textFlashcard.lastReviewed,
-                "userId" to textFlashcard.userId,
-                "folderId" to textFlashcard.folderId,
-                "noteId" to textFlashcard.noteId,
-                "type" to Flashcard.Type.TEXT.toString()))
+    `when`(mockDocumentSnapshot.id).thenReturn(flashcard.id)
+    `when`(mockDocumentSnapshot.getString("front")).thenReturn(flashcard.front)
+    `when`(mockDocumentSnapshot.getString("back")).thenReturn(flashcard.back)
+    `when`(mockDocumentSnapshot.getString("latexFormula")).thenReturn(flashcard.latexFormula)
+    `when`(mockDocumentSnapshot.getBoolean("hasImage")).thenReturn(flashcard.hasImage)
+    `when`(mockDocumentSnapshot.get("fakeBacks")).thenReturn(flashcard.fakeBacks)
+    `when`(mockDocumentSnapshot.getTimestamp("lastReviewed")).thenReturn(flashcard.lastReviewed)
+    `when`(mockDocumentSnapshot.getString("userId")).thenReturn(flashcard.userId)
+    `when`(mockDocumentSnapshot.getString("folderId")).thenReturn(flashcard.folderId)
+    `when`(mockDocumentSnapshot.getString("noteId")).thenReturn(flashcard.noteId)
   }
 
   @Test
@@ -145,54 +121,17 @@ class FlashcardRepositoryFirestoreTest {
     assertNull(flashcardRepositoryFirestore.documentSnapshotToFlashcard(mockBadDocumentSnapshot))
     verifyErrorLog("Error converting document to Flashcard")
 
-    // Successful conversions: -------------------------------------------------------------------
-    // Mock the DocumentSnapshot to return expected fields for a TextFlashcard
+    // Successful conversion of a DocumentSnapshot to a Flashcard
     val convertedTextFlashcard =
         flashcardRepositoryFirestore.documentSnapshotToFlashcard(mockDocumentSnapshot)
-    assertEquals(textFlashcard, convertedTextFlashcard)
-
-    // Mock the DocumentSnapshot to return expected fields for an ImageFlashcard
-    `when`(mockDocumentSnapshot.getString("type")).thenReturn(Flashcard.Type.IMAGE.toString())
-    `when`(mockDocumentSnapshot.data)
-        .thenReturn(
-            mapOf(
-                "id" to imageFlashcard.id,
-                "front" to imageFlashcard.front,
-                "back" to imageFlashcard.back,
-                "lastReviewed" to imageFlashcard.lastReviewed,
-                "userId" to imageFlashcard.userId,
-                "folderId" to imageFlashcard.folderId,
-                "noteId" to imageFlashcard.noteId,
-                "imageUrl" to imageFlashcard.imageUrl,
-                "type" to Flashcard.Type.IMAGE.toString()))
-    val convertedImageFlashcard =
-        flashcardRepositoryFirestore.documentSnapshotToFlashcard(mockDocumentSnapshot)
-    assertEquals(imageFlashcard, convertedImageFlashcard)
-
-    // Mock the DocumentSnapshot to return expected fields for an MCQFlashcard
-    `when`(mockDocumentSnapshot.getString("type")).thenReturn(Flashcard.Type.MCQ.toString())
-    `when`(mockDocumentSnapshot.data)
-        .thenReturn(
-            mapOf(
-                "id" to mcqFlashcard.id,
-                "front" to mcqFlashcard.front,
-                "back" to mcqFlashcard.back,
-                "fakeBacks" to mcqFlashcard.fakeBacks,
-                "lastReviewed" to mcqFlashcard.lastReviewed,
-                "userId" to mcqFlashcard.userId,
-                "folderId" to mcqFlashcard.folderId,
-                "noteId" to mcqFlashcard.noteId,
-                "type" to Flashcard.Type.MCQ.toString()))
-    val convertedMCQFlashcard =
-        flashcardRepositoryFirestore.documentSnapshotToFlashcard(mockDocumentSnapshot)
-    assertEquals(mcqFlashcard, convertedMCQFlashcard)
+    assertEquals(flashcard, convertedTextFlashcard)
   }
 
   @Test
   fun getNewUid() {
-    `when`(mockDocumentReference.id).thenReturn(textFlashcard.id)
+    `when`(mockDocumentReference.id).thenReturn(flashcard.id)
     val uid = flashcardRepositoryFirestore.getNewUid()
-    assert(uid == textFlashcard.id)
+    assert(uid == flashcard.id)
   }
 
   @Test
@@ -204,7 +143,7 @@ class FlashcardRepositoryFirestoreTest {
 
     // Call the method under test
     flashcardRepositoryFirestore.getFlashcardsFrom(
-        textFlashcard.userId,
+        flashcard.userId,
         onSuccess = { flashcard -> flashcardTest = flashcard.firstOrNull() },
         onFailure = { fail("Failure callback should not be called") })
 
@@ -213,7 +152,7 @@ class FlashcardRepositoryFirestoreTest {
 
     // Assertions to verify that the correct flashcard is returned
     assertNotNull(flashcardTest)
-    assertEquals(textFlashcard, flashcardTest)
+    assertEquals(flashcard, flashcardTest)
   }
 
   @Test
@@ -228,7 +167,7 @@ class FlashcardRepositoryFirestoreTest {
     // Call getUserByEmail
     var failureCalled = false
     flashcardRepositoryFirestore.getFlashcardsFrom(
-        textFlashcard.userId,
+        flashcard.userId,
         onSuccess = { fail("Success callback should not be called") },
         onFailure = { failureCalled = true })
     assert(failureCalled)
@@ -240,7 +179,7 @@ class FlashcardRepositoryFirestoreTest {
 
     // Call the method under test
     flashcardRepositoryFirestore.getFlashcardById(
-        textFlashcard.id,
+        flashcard.id,
         onSuccess = { flashcard -> flashcardTest = flashcard },
         onFailure = { fail("Failure callback should not be called") })
 
@@ -249,7 +188,7 @@ class FlashcardRepositoryFirestoreTest {
 
     // Assertions to verify that the correct flashcard is returned
     assertNotNull(flashcardTest)
-    assertEquals(textFlashcard, flashcardTest)
+    assertEquals(flashcard, flashcardTest)
   }
 
   @Test
@@ -264,7 +203,7 @@ class FlashcardRepositoryFirestoreTest {
     // Call getUserByEmail
     var failureCalled = false
     flashcardRepositoryFirestore.getFlashcardById(
-        textFlashcard.id,
+        flashcard.id,
         onSuccess = { fail("Success callback should not be called") },
         onFailure = { failureCalled = true })
     assert(failureCalled)
@@ -280,7 +219,7 @@ class FlashcardRepositoryFirestoreTest {
 
     // Call the method under test
     flashcardRepositoryFirestore.getFlashcardsByFolder(
-        textFlashcard.folderId!!,
+        flashcard.folderId!!,
         onSuccess = { flashcards -> flashcardTest = flashcards.firstOrNull() },
         onFailure = { fail("Failure callback should not be called") })
 
@@ -289,7 +228,7 @@ class FlashcardRepositoryFirestoreTest {
 
     // Assertions to verify that the correct flashcard is returned
     assertNotNull(flashcardTest)
-    assertEquals(textFlashcard, flashcardTest)
+    assertEquals(flashcard, flashcardTest)
   }
 
   @Test
@@ -309,7 +248,7 @@ class FlashcardRepositoryFirestoreTest {
     }
 
     flashcardRepositoryFirestore.getFlashcardsByFolder(
-        textFlashcard.folderId!!,
+        flashcard.folderId!!,
         onSuccess = { fail("Success callback should not be called") },
         onFailure = { assertEquals(testException, it) })
 
@@ -326,7 +265,7 @@ class FlashcardRepositoryFirestoreTest {
 
     // Call the method under test
     flashcardRepositoryFirestore.getFlashcardsByNote(
-        textFlashcard.noteId!!,
+        flashcard.noteId!!,
         onSuccess = { flashcard -> flashcardTest = flashcard.firstOrNull() },
         onFailure = { fail("Failure callback should not be called") })
 
@@ -335,7 +274,7 @@ class FlashcardRepositoryFirestoreTest {
 
     // Assertions to verify that the correct flashcard is returned
     assertNotNull(flashcardTest)
-    assertEquals(textFlashcard, flashcardTest)
+    assertEquals(flashcard, flashcardTest)
   }
 
   @Test
@@ -355,7 +294,7 @@ class FlashcardRepositoryFirestoreTest {
     }
 
     flashcardRepositoryFirestore.getFlashcardsByNote(
-        textFlashcard.noteId!!,
+        flashcard.noteId!!,
         onSuccess = { fail("Success callback should not be called") },
         onFailure = { assertEquals(testException, it) })
 
@@ -368,7 +307,7 @@ class FlashcardRepositoryFirestoreTest {
 
     // This test verifies that when we add a new flashcard, the Firestore `collection()` method is
     // called.
-    flashcardRepositoryFirestore.addFlashcard(textFlashcard, onSuccess = {}, onFailure = {})
+    flashcardRepositoryFirestore.addFlashcard(flashcard, onSuccess = {}, onFailure = {})
 
     shadowOf(Looper.getMainLooper()).idle()
 
@@ -390,7 +329,7 @@ class FlashcardRepositoryFirestoreTest {
     }
 
     flashcardRepositoryFirestore.addFlashcard(
-        textFlashcard,
+        flashcard,
         onSuccess = { fail("Success callback should not be called") },
         onFailure = { assertEquals(testException, it) })
 
@@ -403,7 +342,7 @@ class FlashcardRepositoryFirestoreTest {
 
     // This test verifies that when we update a flashcard, the Firestore `collection()` method is
     // called.
-    flashcardRepositoryFirestore.updateFlashcard(textFlashcard, onSuccess = {}, onFailure = {})
+    flashcardRepositoryFirestore.updateFlashcard(flashcard, onSuccess = {}, onFailure = {})
 
     shadowOf(Looper.getMainLooper()).idle()
 
@@ -425,7 +364,7 @@ class FlashcardRepositoryFirestoreTest {
     }
 
     flashcardRepositoryFirestore.updateFlashcard(
-        textFlashcard,
+        flashcard,
         onSuccess = { fail("Success callback should not be called") },
         onFailure = { assertEquals(testException, it) })
 
@@ -436,7 +375,7 @@ class FlashcardRepositoryFirestoreTest {
   fun deleteFlashcard_callsDocument() {
     `when`(mockDocumentReference.delete()).thenReturn(Tasks.forResult(null)) // Simulate success
 
-    flashcardRepositoryFirestore.deleteFlashcard(textFlashcard, onSuccess = {}, onFailure = {})
+    flashcardRepositoryFirestore.deleteFlashcard(flashcard, onSuccess = {}, onFailure = {})
 
     shadowOf(Looper.getMainLooper()).idle()
 
@@ -458,7 +397,7 @@ class FlashcardRepositoryFirestoreTest {
     }
 
     flashcardRepositoryFirestore.deleteFlashcard(
-        textFlashcard,
+        flashcard,
         onSuccess = { fail("Success callback should not be called") },
         onFailure = { assertEquals(testException, it) })
 

--- a/app/src/test/java/com/github/onlynotesswent/model/flashcard/FlashcardTest.kt
+++ b/app/src/test/java/com/github/onlynotesswent/model/flashcard/FlashcardTest.kt
@@ -2,7 +2,6 @@ package com.github.onlynotesswent.model.flashcard
 
 import com.github.onlynotesswent.model.flashcard.deck.Deck
 import com.google.firebase.Timestamp
-import junit.framework.TestCase.assertEquals
 import org.junit.Test
 
 class FlashcardTest {
@@ -20,10 +19,12 @@ class FlashcardTest {
   @Test
   fun `test flashcard creation`() {
     val flashcard =
-        MCQFlashcard(
+        Flashcard(
             id = "1",
             front = "front",
             back = "back",
+            latexFormula = "test",
+            hasImage = true,
             fakeBacks = listOf("fake1", "fake2"),
             lastReviewed = Timestamp(0, 0),
             userId = "2",
@@ -33,99 +34,12 @@ class FlashcardTest {
     assert(flashcard.id == "1")
     assert(flashcard.front == "front")
     assert(flashcard.back == "back")
+    assert(flashcard.latexFormula == "test")
+    assert(flashcard.hasImage)
     assert(flashcard.fakeBacks == listOf("fake1", "fake2"))
     assert(flashcard.lastReviewed == Timestamp(0, 0))
     assert(flashcard.userId == "2")
     assert(flashcard.folderId == "3")
     assert(flashcard.noteId == "4")
-  }
-
-  @Test
-  fun `test flashcard equality and hash`() {
-    val flashcard1 =
-        MCQFlashcard(
-            id = "1",
-            front = "front",
-            back = "back",
-            fakeBacks = listOf("fake1", "fake2"),
-            lastReviewed = Timestamp(0, 0),
-            userId = "2",
-            folderId = "3",
-            noteId = "4")
-    val flashcard2 =
-        MCQFlashcard(
-            id = "1",
-            front = "front",
-            back = "back",
-            fakeBacks = listOf("fake1", "fake2"),
-            lastReviewed = Timestamp(0, 0),
-            userId = "2",
-            folderId = "3",
-            noteId = "4")
-    assertEquals(flashcard1, flashcard2)
-    assertEquals(flashcard1.hashCode(), flashcard2.hashCode())
-  }
-
-  @Test
-  fun `test flashcard to from map`() {
-    val flashcard =
-        MCQFlashcard(
-            id = "1",
-            front = "front",
-            back = "back",
-            fakeBacks = listOf("fake1", "fake2"),
-            lastReviewed = Timestamp(0, 0),
-            userId = "2",
-            folderId = "3",
-            noteId = "4")
-    val mcqMap = flashcard.toMap()
-    val mcqNewFlashcard = Flashcard.from(Flashcard.Type.MCQ, mcqMap)
-    assertEquals(flashcard, mcqNewFlashcard)
-
-    val textFlashcard =
-        TextFlashcard(
-            id = "1",
-            front = "front",
-            back = "back",
-            lastReviewed = Timestamp(0, 0),
-            userId = "2",
-            folderId = "3",
-            noteId = "4")
-
-    val textMap = textFlashcard.toMap()
-    val newTextFlashcard = Flashcard.from(Flashcard.Type.TEXT, textMap)
-    assertEquals(textFlashcard, newTextFlashcard)
-
-    val imageFlashcard =
-        ImageFlashcard(
-            id = "1",
-            front = "front",
-            back = "back",
-            imageUrl = "url",
-            lastReviewed = Timestamp(0, 0),
-            userId = "2",
-            folderId = "3",
-            noteId = "4")
-
-    val imageMap = imageFlashcard.toMap()
-    val newImageFlashcard = Flashcard.from(Flashcard.Type.IMAGE, imageMap)
-    assertEquals(imageFlashcard, newImageFlashcard)
-  }
-
-  @Test
-  fun `test flashcard type from string`() {
-    assertEquals(Flashcard.Type.TEXT, Flashcard.Type.fromString("TEXT"))
-    assertEquals(Flashcard.Type.IMAGE, Flashcard.Type.fromString("IMAGE"))
-    assertEquals(Flashcard.Type.MCQ, Flashcard.Type.fromString("MCQ"))
-  }
-
-  @Test(expected = IllegalArgumentException::class)
-  fun `test flashcard type from string exception`() {
-    Flashcard.Type.fromString("INVALID")
-  }
-
-  @Test(expected = IllegalArgumentException::class)
-  fun `test flashcard type from string exception empty`() {
-    Flashcard.Type.fromString("")
   }
 }

--- a/app/src/test/java/com/github/onlynotesswent/model/flashcard/FlashcardViewModelTest.kt
+++ b/app/src/test/java/com/github/onlynotesswent/model/flashcard/FlashcardViewModelTest.kt
@@ -22,7 +22,7 @@ class FlashcardViewModelTest {
   private lateinit var flashcardViewModel: FlashcardViewModel
 
   private val flashcard =
-      TextFlashcard(
+      Flashcard(
           id = "1",
           front = "front",
           back = "back",


### PR DESCRIPTION
# Description

I am changing back Flashcards from multiple inherited classes to a single data class like before but with new fields. It now looks like this, no fuss:

```
/**
 * Represents a flashcard.
 *
 * @property id The ID of the flashcard.
 * @property front The front side of the flashcard which contains the question.
 * @property back The back side of the flashcard which contains the answer.
 * @property latexFormula The latex formula for the flashcard, if any.
 * @property hasImage A flag indicating if the flashcard has an image.
 * @property fakeBacks The fake backs of the flashcard for MCQs, if any.
 * @property lastReviewed The timestamp of the last review of the flashcard.
 * @property userId The ID of the user who created the flashcard.
 * @property folderId The ID of the folder that the flashcard belongs to.
 * @property noteId The ID of the note that the flashcard belongs to.
 */
data class Flashcard(
    val id: String,
    val front: String, // The front side of the flashcard which contains the question.
    val back: String, // The back side of the flashcard which contains the answer.
    val latexFormula: String = "", // The latex formula for the flashcard, if any.
    val hasImage: Boolean = false, // A flag indicating if the flashcard has an image.
    val fakeBacks: List<String> = emptyList(), // The fake backs of the flashcard for MCQs, if any.
    val lastReviewed: Timestamp?,
    val userId: String,
    val folderId: String?,
    val noteId: String?
)
```

Fixes #191 

# How Has This Been Tested?

Removed all new tests on inherited flashcard classes. All others pass.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged in downstream modules, no conflicts with main
