### PR TITLE
Feature: create flashcard play composables

### DIFF
--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/deck/DeckPlayTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/deck/DeckPlayTest.kt
@@ -1,0 +1,140 @@
+package com.github.onlynotesswent.ui.deck
+
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.onlynotesswent.model.common.Visibility
+import com.github.onlynotesswent.model.file.FileRepository
+import com.github.onlynotesswent.model.file.FileViewModel
+import com.github.onlynotesswent.model.flashcard.Flashcard
+import com.github.onlynotesswent.model.flashcard.FlashcardRepository
+import com.github.onlynotesswent.model.flashcard.FlashcardViewModel
+import com.github.onlynotesswent.model.flashcard.deck.Deck
+import com.github.onlynotesswent.model.flashcard.deck.DeckRepository
+import com.github.onlynotesswent.model.flashcard.deck.DeckViewModel
+import com.github.onlynotesswent.model.user.User
+import com.github.onlynotesswent.model.user.UserRepository
+import com.github.onlynotesswent.model.user.UserViewModel
+import com.github.onlynotesswent.ui.common.FlashcardPlayItem
+import com.google.firebase.Timestamp
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.times
+
+@RunWith(AndroidJUnit4::class)
+class DeckPlayTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Mock private lateinit var deckRepository: DeckRepository
+  @Mock private lateinit var flashcardRepository: FlashcardRepository
+  @Mock private lateinit var fileRepository: FileRepository
+  @Mock private lateinit var userRepository: UserRepository
+  private lateinit var userViewModel: UserViewModel
+  private lateinit var deckViewModel: DeckViewModel
+  private lateinit var flashcardViewModel: FlashcardViewModel
+  private lateinit var fileViewModel: FileViewModel
+
+  private val testUser =
+      User(
+          uid = "testUser",
+          email = "testEmail",
+          userName = "testUsername",
+          firstName = "testFirstName",
+          lastName = "testLastName",
+      )
+
+  private val testFlashcard1 =
+      Flashcard(
+          id = "testFlashcard1",
+          front = "testFront1",
+          back = "testBack1",
+          userId = "testUser",
+          folderId = null,
+          noteId = null)
+
+  private val testFlashcard2 =
+      Flashcard(
+          id = "testFlashcard2",
+          front = "testFront2",
+          back = "testBack2",
+          fakeBacks = listOf("fakeBack1", "fakeBack2"),
+          userId = "testUser",
+          folderId = null,
+          noteId = null)
+
+  private val testDeck =
+      Deck(
+          id = "testDeck",
+          name = "testDeckName",
+          description = "testDeckDescription",
+          userId = "testUser",
+          visibility = Visibility.PUBLIC,
+          flashcardIds = listOf("testFlashcard1", "testFlashcard2"),
+          lastModified = Timestamp.now(),
+          folderId = null)
+
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+    userViewModel = UserViewModel(userRepository)
+    deckViewModel = DeckViewModel(deckRepository)
+    flashcardViewModel = FlashcardViewModel(flashcardRepository)
+    fileViewModel = FileViewModel(fileRepository)
+
+    `when`(userRepository.addUser(any(), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<() -> Unit>(1)
+      onSuccess()
+    }
+
+    `when`(flashcardRepository.getFlashcardsById(any(), any(), any())).thenAnswer {
+      val flashcardIds = it.getArgument<List<String>>(0)
+      val onSuccess = it.getArgument<(List<Flashcard>) -> Unit>(1)
+      onSuccess(
+          flashcardIds.mapNotNull { id ->
+            when (id) {
+              "testFlashcard1" -> testFlashcard1
+              "testFlashcard2" -> testFlashcard2
+              else -> null
+            }
+          })
+    }
+
+    `when`(deckRepository.getDeckById(any(), any(), any())).thenAnswer {
+      val onSuccess = it.getArgument<(Deck) -> Unit>(1)
+      onSuccess(testDeck)
+    }
+    userViewModel.addUser(testUser)
+    deckViewModel.selectDeck(testDeck)
+    flashcardViewModel.fetchFlashcardsFromDeck(testDeck)
+  }
+
+  @Test
+  fun normalFlashcardPlayItem() {
+    var onCorrectCalled = false
+    var onIncorrectCalled = false
+
+    composeTestRule.setContent {
+      FlashcardPlayItem(
+          flashcard = testFlashcard1,
+          fileViewModel = fileViewModel,
+          onCorrect = { onCorrectCalled = true },
+          onIncorrect = { onIncorrectCalled = true })
+    }
+
+    // Test that the front of the flashcard is displayed
+    composeTestRule.onNodeWithTag("flashcardFront", true).assertTextEquals("testFront1")
+    // Flip the flashcard
+    composeTestRule.onNodeWithTag("flashcard").performClick()
+    // Test that the back of the flashcard is displayed
+    composeTestRule.onNodeWithTag("flashcardBack", true).assertTextEquals("testBack1")
+  }
+}

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/deck/DeckPlayTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/deck/DeckPlayTest.kt
@@ -129,7 +129,7 @@ class DeckPlayTest {
 
     composeTestRule.setContent {
       FlashcardPlayItem(
-          flashcard = remember { mutableStateOf(testFlashcard1) },
+          flashcardState = remember { mutableStateOf(testFlashcard1) },
           fileViewModel = fileViewModel,
           onCorrect = { onCorrectCalled = true },
           onIncorrect = { onIncorrectCalled = true })
@@ -150,7 +150,7 @@ class DeckPlayTest {
 
     composeTestRule.setContent {
       FlashcardPlayItem(
-          flashcard = remember { mutableStateOf(testFlashcard2) },
+          flashcardState = remember { mutableStateOf(testFlashcard2) },
           fileViewModel = fileViewModel,
           onCorrect = { onCorrectCalled = true },
           onIncorrect = { onIncorrectCalled = true })

--- a/app/src/main/java/com/github/onlynotesswent/MainActivity.kt
+++ b/app/src/main/java/com/github/onlynotesswent/MainActivity.kt
@@ -176,7 +176,8 @@ fun OnlyNotesApp(
               deckViewModel.getDeckById(
                   deckId, { deckViewModel.playDeckWithMode(it, Deck.PlayMode.fromString(mode)) })
         }
-        DeckPlayScreen()
+        DeckPlayScreen(
+            navigationActions, userViewModel, deckViewModel, flashcardViewModel, fileViewModel)
       }
     }
 

--- a/app/src/main/java/com/github/onlynotesswent/ui/common/FlashcardComposables.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/common/FlashcardComposables.kt
@@ -654,7 +654,7 @@ fun McqPlayItem(
                   MaterialTheme.colorScheme.onSurface
                 }
             ElevatedCard(
-                modifier = Modifier.fillMaxWidth(0.7f).padding(10.dp).testTag("flashcardChoice"),
+                modifier = Modifier.fillMaxWidth(0.7f).padding(horizontal = 10.dp).testTag("flashcardChoice"),
                 onClick = {
                   if (choice.value == null) {
                     choice.value = index

--- a/app/src/main/java/com/github/onlynotesswent/ui/common/FlashcardComposables.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/common/FlashcardComposables.kt
@@ -160,14 +160,14 @@ fun FlashcardViewItem(
                 Text(
                     flashcard.front,
                     style = Typography.bodyMedium,
-                    modifier = Modifier.testTag("flashcardFront--${flashcard.id}").padding(20.dp))
-                FlashcardImage(flashcard, fileViewModel, padding = 10.dp)
-                HorizontalDivider(modifier = Modifier.height(5.dp).padding(10.dp))
+                    modifier = Modifier.testTag("flashcardFront--${flashcard.id}").padding(5.dp))
+                FlashcardImage(flashcard, fileViewModel)
+                HorizontalDivider(modifier = Modifier.height(5.dp).padding(5.dp))
                 // Show back
                 Text(
                     flashcard.back,
                     style = Typography.bodyMedium,
-                    modifier = Modifier.testTag("flashcardBack--${flashcard.id}").padding(20.dp))
+                    modifier = Modifier.testTag("flashcardBack--${flashcard.id}").padding(5.dp))
               }
         }
       }
@@ -411,6 +411,9 @@ fun FlashcardDialog(
                     val newHasImage: Boolean =
                         if (hasImageBeenChanged.value) imageUri.value != null
                         else flashcard.value?.hasImage == true
+
+                    // Remove empty fake backs
+                    fakeBacks.value = fakeBacks.value.filter { it.isNotBlank() }
 
                     val newFlashcard: Flashcard =
                         flashcard.value?.copy(

--- a/app/src/main/java/com/github/onlynotesswent/ui/common/FlashcardComposables.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/common/FlashcardComposables.kt
@@ -1,6 +1,5 @@
 package com.github.onlynotesswent.ui.common
 
-import android.util.Log
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.FastOutSlowInEasing
@@ -58,9 +57,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
@@ -656,7 +653,10 @@ fun McqPlayItem(
                   MaterialTheme.colorScheme.onSurface
                 }
             ElevatedCard(
-                modifier = Modifier.fillMaxWidth(0.7f).padding(horizontal = 10.dp).testTag("flashcardChoice"),
+                modifier =
+                    Modifier.fillMaxWidth(0.7f)
+                        .padding(horizontal = 10.dp)
+                        .testTag("flashcardChoice"),
                 onClick = {
                   if (choice.value == null) {
                     choice.value = index
@@ -717,7 +717,7 @@ fun FlashcardImage(
     imageUri: MutableState<String?> = remember { mutableStateOf(null) },
     padding: Dp = 10.dp,
 ) {
-  if (compareUID(imageUri.value,flashcard.value.id, FileType.FLASHCARD_IMAGE.fileExtension)) {
+  if (compareUID(imageUri.value, flashcard.value.id, FileType.FLASHCARD_IMAGE.fileExtension)) {
     Image(
         painter = rememberAsyncImagePainter(imageUri.value!!),
         contentDescription = "Flashcard image",

--- a/app/src/main/java/com/github/onlynotesswent/ui/common/FlashcardComposables.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/common/FlashcardComposables.kt
@@ -44,6 +44,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
@@ -625,9 +626,7 @@ fun McqPlayItem(
           flashcard.fakeBacks.filter { it != flashcard.back && it.isNotBlank() }
   val shuffledIndexes = backs.indices.shuffled()
 
-  ElevatedCard(
-      modifier = Modifier.fillMaxWidth(0.9f).padding(5.dp),
-      elevation = CardDefaults.elevatedCardElevation(defaultElevation = 4.dp)) {
+  ElevatedCard(modifier = Modifier.fillMaxWidth(0.9f).padding(5.dp)) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(20.dp),
@@ -666,13 +665,13 @@ fun McqPlayItem(
                     },
                     elevation =
                         if (choice.value == index)
-                            CardDefaults.elevatedCardElevation(defaultElevation = 5.dp)
-                        else CardDefaults.elevatedCardElevation(defaultElevation = 3.dp)) {
+                            CardDefaults.elevatedCardElevation(defaultElevation = 4.dp)
+                        else CardDefaults.elevatedCardElevation(defaultElevation = 2.dp)) {
                       Row(
                           modifier = Modifier.fillMaxWidth().padding(5.dp),
                           horizontalArrangement = Arrangement.spacedBy(10.dp),
                           verticalAlignment = Alignment.CenterVertically) {
-                            AnimatedContent(choice.value?.let { it == index }, label = "") {
+                            AnimatedContent(choice.value?.let { index == 0 }, label = "") {
                               when (it) {
                                 null ->
                                     Icon(

--- a/app/src/main/java/com/github/onlynotesswent/ui/common/FlashcardComposables.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/common/FlashcardComposables.kt
@@ -58,7 +58,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
@@ -715,9 +717,7 @@ fun FlashcardImage(
     imageUri: MutableState<String?> = remember { mutableStateOf(null) },
     padding: Dp = 10.dp,
 ) {
-
-  if (extractUID(imageUri.value) == flashcard.value.id) {
-    Log.d("FlashcardImage", "Image URI: ${imageUri.value}")
+  if (compareUID(imageUri.value,flashcard.value.id, FileType.FLASHCARD_IMAGE.fileExtension)) {
     Image(
         painter = rememberAsyncImagePainter(imageUri.value!!),
         contentDescription = "Flashcard image",

--- a/app/src/main/java/com/github/onlynotesswent/ui/common/FlashcardComposables.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/common/FlashcardComposables.kt
@@ -160,14 +160,14 @@ fun FlashcardViewItem(
                 Text(
                     flashcard.front,
                     style = Typography.bodyMedium,
-                    modifier = Modifier.testTag("flashcardFront--${flashcard.id}").padding(5.dp))
+                    modifier = Modifier.testTag("flashcardFront--${flashcard.id}").padding(10.dp))
                 FlashcardImage(flashcard, fileViewModel)
                 HorizontalDivider(modifier = Modifier.height(5.dp).padding(5.dp))
                 // Show back
                 Text(
                     flashcard.back,
                     style = Typography.bodyMedium,
-                    modifier = Modifier.testTag("flashcardBack--${flashcard.id}").padding(5.dp))
+                    modifier = Modifier.testTag("flashcardBack--${flashcard.id}").padding(20.dp))
               }
         }
       }

--- a/app/src/main/java/com/github/onlynotesswent/ui/common/FlashcardComposables.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/common/FlashcardComposables.kt
@@ -6,8 +6,6 @@ import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
@@ -117,58 +115,62 @@ fun FlashcardViewItem(
   }
 
   ElevatedCard(
-      modifier = Modifier.testTag("flashcardItem--${flashcard.id}").fillMaxWidth().heightIn(min = 160.dp)
-  ) {
-    Box(contentAlignment = Alignment.Center, modifier = Modifier.padding(10.dp)) {
-      if (flashcard.isMCQ()) {
-        Text(
-            stringResource(R.string.mcq),
-            style = Typography.bodyLarge,
-            fontStyle = FontStyle.Italic,
-            modifier = Modifier.align(Alignment.TopStart).testTag("flashcardMCQ--${flashcard.id}"))
-      }
-      // Show front and options icon
-      Column(modifier = Modifier.align(Alignment.TopEnd)) {
-        Icon(
-            modifier =
-                Modifier.testTag("flashcardOptions--${flashcard.id}").clickable(
-                    enabled = belongsToUser) {
-                      dropdownMenuExpanded.value = true
-                    },
-            imageVector = Icons.Filled.MoreVert,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onPrimaryContainer)
-        AnimatedVisibility(dropdownMenuExpanded.value,
-            enter = expandVertically(tween(700)),
-            exit = shrinkVertically(tween(700))) {
-          FlashcardItemDropdownMenu(
-              flashcard,
-              deckViewModel,
-              flashcardViewModel,
-              dropdownMenuExpanded,
-              editDialogExpanded)
+      modifier =
+          Modifier.testTag("flashcardItem--${flashcard.id}")
+              .fillMaxWidth()
+              .heightIn(min = 160.dp)) {
+        Box(contentAlignment = Alignment.Center, modifier = Modifier.padding(10.dp)) {
+          if (flashcard.isMCQ()) {
+            Text(
+                stringResource(R.string.mcq),
+                style = Typography.bodyLarge,
+                fontStyle = FontStyle.Italic,
+                modifier =
+                    Modifier.align(Alignment.TopStart).testTag("flashcardMCQ--${flashcard.id}"))
+          }
+          // Show front and options icon
+          Column(modifier = Modifier.align(Alignment.TopEnd)) {
+            Icon(
+                modifier =
+                    Modifier.testTag("flashcardOptions--${flashcard.id}").clickable(
+                        enabled = belongsToUser) {
+                          dropdownMenuExpanded.value = true
+                        },
+                imageVector = Icons.Filled.MoreVert,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer)
+            AnimatedVisibility(
+                dropdownMenuExpanded.value,
+                enter = expandVertically(tween(700)),
+                exit = shrinkVertically(tween(700))) {
+                  FlashcardItemDropdownMenu(
+                      flashcard,
+                      deckViewModel,
+                      flashcardViewModel,
+                      dropdownMenuExpanded,
+                      editDialogExpanded)
+                }
+          }
+          Column(
+              horizontalAlignment = Alignment.CenterHorizontally,
+              verticalArrangement = Arrangement.SpaceAround,
+              modifier =
+                  Modifier.testTag("flashcardItemColumn")
+                      .semantics(mergeDescendants = true, properties = {})) {
+                Text(
+                    flashcard.front,
+                    style = Typography.bodyMedium,
+                    modifier = Modifier.testTag("flashcardFront--${flashcard.id}").padding(20.dp))
+                FlashcardImage(flashcard, fileViewModel, padding = 10.dp)
+                HorizontalDivider(modifier = Modifier.height(5.dp).padding(10.dp))
+                // Show back
+                Text(
+                    flashcard.back,
+                    style = Typography.bodyMedium,
+                    modifier = Modifier.testTag("flashcardBack--${flashcard.id}").padding(20.dp))
+              }
         }
       }
-      Column(
-          horizontalAlignment = Alignment.CenterHorizontally,
-          verticalArrangement = Arrangement.SpaceAround,
-          modifier =
-              Modifier.testTag("flashcardItemColumn")
-                  .semantics(mergeDescendants = true, properties = {})) {
-            Text(
-                flashcard.front,
-                style = Typography.bodyMedium,
-                modifier = Modifier.testTag("flashcardFront--${flashcard.id}").padding(20.dp))
-            FlashcardImage(flashcard, fileViewModel, padding = 10.dp)
-            HorizontalDivider(modifier = Modifier.height(5.dp).padding(10.dp))
-            // Show back
-            Text(
-                flashcard.back,
-                style = Typography.bodyMedium,
-                modifier = Modifier.testTag("flashcardBack--${flashcard.id}").padding(20.dp))
-          }
-    }
-  }
 }
 
 /**
@@ -571,11 +573,12 @@ fun NormalFlashcardPlayItem(
           Modifier.fillMaxWidth(0.9f)
               .padding(5.dp)
               .graphicsLayer {
-                  rotationY = when(flipState.value){
-                        FlipState.FRONT -> 360f - rotation.value // same rotation for both sides
-                        FlipState.BACK -> rotation.value
-                  }
-                  cameraDistance = 15 * density
+                rotationY =
+                    when (flipState.value) {
+                      FlipState.FRONT -> 360f - rotation.value // same rotation for both sides
+                      FlipState.BACK -> rotation.value
+                    }
+                cameraDistance = 15 * density
               }
               .clickable { flipState.value = flipState.value.next }) {
         Column(
@@ -622,82 +625,82 @@ fun McqPlayItem(
   ElevatedCard(
       modifier = Modifier.fillMaxWidth(0.9f).padding(5.dp),
       elevation = CardDefaults.elevatedCardElevation(defaultElevation = 4.dp)) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(20.dp),
-        modifier =
-            Modifier.fillMaxWidth()
-                .padding(vertical = 30.dp, horizontal = 10.dp)
-                .heightIn(min = 200.dp, max = 600.dp)) {
-          Text(
-              flashcard.front,
-              style = Typography.bodyLarge,
-              fontWeight = FontWeight(550),
-              modifier = Modifier.testTag("flashcardFront--${flashcard.id}"))
-          FlashcardImage(flashcard, fileViewModel)
-          HorizontalDivider(modifier = Modifier.height(5.dp).fillMaxWidth().padding(8.dp))
-          shuffledIndexes.forEach { index ->
-            val color = remember { mutableStateOf(Color.Gray) }
-            color.value =
-                if (choice.value != null && index == 0) {
-                  Color.Green.copy(green = 0.6f, blue = 0.3f, red = 0.3f)
-                } else if (choice.value == index) {
-                  Color.Red.copy(red = 0.7f, blue = 0.3f)
-                } else {
-                  MaterialTheme.colorScheme.onSurface
-                }
-            ElevatedCard(
-                modifier = Modifier.fillMaxWidth(0.7f).padding(10.dp),
-                onClick = {
-                  if (choice.value == null) {
-                    choice.value = index
-                    if (index == 0) {
-                      onCorrect()
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+            modifier =
+                Modifier.fillMaxWidth()
+                    .padding(vertical = 30.dp, horizontal = 10.dp)
+                    .heightIn(min = 200.dp, max = 600.dp)) {
+              Text(
+                  flashcard.front,
+                  style = Typography.bodyLarge,
+                  fontWeight = FontWeight(550),
+                  modifier = Modifier.testTag("flashcardFront--${flashcard.id}"))
+              FlashcardImage(flashcard, fileViewModel)
+              HorizontalDivider(modifier = Modifier.height(5.dp).fillMaxWidth().padding(8.dp))
+              shuffledIndexes.forEach { index ->
+                val color = remember { mutableStateOf(Color.Gray) }
+                color.value =
+                    if (choice.value != null && index == 0) {
+                      Color.Green.copy(green = 0.6f, blue = 0.3f, red = 0.3f)
+                    } else if (choice.value == index) {
+                      Color.Red.copy(red = 0.7f, blue = 0.3f)
                     } else {
-                      onIncorrect()
+                      MaterialTheme.colorScheme.onSurface
                     }
-                  }
-                },
-                elevation =
-                    if (choice.value == index)
-                        CardDefaults.elevatedCardElevation(defaultElevation = 5.dp)
-                    else CardDefaults.elevatedCardElevation(defaultElevation = 3.dp)) {
-                  Row(
-                      modifier = Modifier.fillMaxWidth().padding(5.dp),
-                      horizontalArrangement = Arrangement.spacedBy(10.dp),
-                      verticalAlignment = Alignment.CenterVertically) {
-                        AnimatedContent(choice.value?.let { it == index }, label = "") {
-                          when (it) {
-                            null ->
-                                Icon(
-                                    imageVector = Icons.Default.CheckBoxOutlineBlank,
-                                    contentDescription = null,
-                                    tint = color.value,
-                                    modifier = Modifier.padding(5.dp))
-                            true ->
-                                Icon(
-                                    imageVector = Icons.Default.Check,
-                                    contentDescription = null,
-                                    tint = color.value,
-                                    modifier = Modifier.padding(5.dp))
-                            false ->
-                                Icon(
-                                    imageVector = Icons.Default.Close,
-                                    contentDescription = null,
-                                    tint = color.value,
-                                    modifier = Modifier.padding(5.dp))
-                          }
+                ElevatedCard(
+                    modifier = Modifier.fillMaxWidth(0.7f).padding(10.dp),
+                    onClick = {
+                      if (choice.value == null) {
+                        choice.value = index
+                        if (index == 0) {
+                          onCorrect()
+                        } else {
+                          onIncorrect()
                         }
-                        Text(
-                            backs[index],
-                            style = Typography.bodyMedium,
-                            color = color.value,
-                            modifier = Modifier.testTag("flashcardBack--${flashcard.id}"))
                       }
-                }
-          }
-        }
-  }
+                    },
+                    elevation =
+                        if (choice.value == index)
+                            CardDefaults.elevatedCardElevation(defaultElevation = 5.dp)
+                        else CardDefaults.elevatedCardElevation(defaultElevation = 3.dp)) {
+                      Row(
+                          modifier = Modifier.fillMaxWidth().padding(5.dp),
+                          horizontalArrangement = Arrangement.spacedBy(10.dp),
+                          verticalAlignment = Alignment.CenterVertically) {
+                            AnimatedContent(choice.value?.let { it == index }, label = "") {
+                              when (it) {
+                                null ->
+                                    Icon(
+                                        imageVector = Icons.Default.CheckBoxOutlineBlank,
+                                        contentDescription = null,
+                                        tint = color.value,
+                                        modifier = Modifier.padding(5.dp))
+                                true ->
+                                    Icon(
+                                        imageVector = Icons.Default.Check,
+                                        contentDescription = null,
+                                        tint = color.value,
+                                        modifier = Modifier.padding(5.dp))
+                                false ->
+                                    Icon(
+                                        imageVector = Icons.Default.Close,
+                                        contentDescription = null,
+                                        tint = color.value,
+                                        modifier = Modifier.padding(5.dp))
+                              }
+                            }
+                            Text(
+                                backs[index],
+                                style = Typography.bodyMedium,
+                                color = color.value,
+                                modifier = Modifier.testTag("flashcardBack--${flashcard.id}"))
+                          }
+                    }
+              }
+            }
+      }
 }
 
 @Composable
@@ -705,13 +708,14 @@ fun FlashcardImage(
     flashcard: Flashcard,
     fileViewModel: FileViewModel,
     imageUri: MutableState<String?> = remember { mutableStateOf(null) },
-    padding:Dp = 10.dp,
+    padding: Dp = 10.dp,
 ) {
   if (imageUri.value != null) {
     Image(
         painter = rememberAsyncImagePainter(imageUri.value!!),
         contentDescription = "Flashcard image",
-        modifier = Modifier.height(100.dp).testTag("flashcardImage--${flashcard.id}").padding(padding))
+        modifier =
+            Modifier.height(100.dp).testTag("flashcardImage--${flashcard.id}").padding(padding))
   } else if (flashcard.hasImage) {
     fileViewModel.downloadFile(
         flashcard.id,
@@ -720,7 +724,10 @@ fun FlashcardImage(
         onSuccess = { file -> imageUri.value = file.absolutePath })
     LoadingIndicator(
         stringResource(R.string.image_is_being_downloaded),
-        modifier = Modifier.fillMaxWidth().testTag("flashcardImageLoading--${flashcard.id}").padding(padding),
+        modifier =
+            Modifier.fillMaxWidth()
+                .testTag("flashcardImageLoading--${flashcard.id}")
+                .padding(padding),
         loadingIndicatorSize = 24.dp,
         spacerHeight = 5.dp,
         style = MaterialTheme.typography.bodySmall)

--- a/app/src/main/java/com/github/onlynotesswent/ui/common/FlashcardComposables.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/common/FlashcardComposables.kt
@@ -44,7 +44,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
@@ -575,6 +574,7 @@ fun NormalFlashcardPlayItem(
   ElevatedCard(
       modifier =
           Modifier.fillMaxWidth(0.9f)
+              .testTag("flashcard")
               .padding(5.dp)
               .graphicsLayer {
                 rotationY =
@@ -597,17 +597,14 @@ fun NormalFlashcardPlayItem(
                     flashcard.front,
                     style = Typography.bodyLarge,
                     fontWeight = FontWeight(450),
-                    modifier = Modifier.testTag("flashcardFront--${flashcard.id}"))
+                    modifier = Modifier.testTag("flashcardFront"))
                 FlashcardImage(flashcard, fileViewModel)
               } else {
                 Text(
                     flashcard.back,
                     style = Typography.bodyLarge,
                     fontWeight = FontWeight(450),
-                    modifier =
-                        Modifier.testTag("flashcardBack--${flashcard.id}").graphicsLayer {
-                          rotationY = 180f
-                        })
+                    modifier = Modifier.testTag("flashcardBack").graphicsLayer { rotationY = 180f })
               }
             }
       }
@@ -626,83 +623,83 @@ fun McqPlayItem(
           flashcard.fakeBacks.filter { it != flashcard.back && it.isNotBlank() }
   val shuffledIndexes = backs.indices.shuffled()
 
-  ElevatedCard(modifier = Modifier.fillMaxWidth(0.9f).padding(5.dp)) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(20.dp),
-            modifier =
-                Modifier.fillMaxWidth()
-                    .padding(vertical = 30.dp, horizontal = 10.dp)
-                    .heightIn(min = 200.dp, max = 600.dp)) {
-              Text(
-                  flashcard.front,
-                  style = Typography.bodyLarge,
-                  fontWeight = FontWeight(550),
-                  modifier = Modifier.testTag("flashcardFront--${flashcard.id}"))
-              FlashcardImage(flashcard, fileViewModel)
-              HorizontalDivider(modifier = Modifier.height(5.dp).fillMaxWidth().padding(8.dp))
-              shuffledIndexes.forEach { index ->
-                val color = remember { mutableStateOf(Color.Gray) }
-                color.value =
-                    if (choice.value != null && index == 0) {
-                      Color.Green.copy(green = 0.6f, blue = 0.3f, red = 0.3f)
-                    } else if (choice.value == index) {
-                      Color.Red.copy(red = 0.7f, blue = 0.3f)
+  ElevatedCard(modifier = Modifier.fillMaxWidth(0.9f).padding(5.dp).testTag("flashcard")) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+        modifier =
+            Modifier.fillMaxWidth()
+                .padding(vertical = 30.dp, horizontal = 10.dp)
+                .heightIn(min = 200.dp, max = 600.dp)) {
+          Text(
+              flashcard.front,
+              style = Typography.bodyLarge,
+              fontWeight = FontWeight(550),
+              modifier = Modifier.testTag("flashcardFront"))
+          FlashcardImage(flashcard, fileViewModel)
+          HorizontalDivider(modifier = Modifier.height(5.dp).fillMaxWidth().padding(8.dp))
+          shuffledIndexes.forEach { index ->
+            val color = remember { mutableStateOf(Color.Gray) }
+            color.value =
+                if (choice.value != null && index == 0) {
+                  Color.Green.copy(green = 0.6f, blue = 0.3f, red = 0.3f)
+                } else if (choice.value == index) {
+                  Color.Red.copy(red = 0.7f, blue = 0.3f)
+                } else {
+                  MaterialTheme.colorScheme.onSurface
+                }
+            ElevatedCard(
+                modifier = Modifier.fillMaxWidth(0.7f).padding(10.dp),
+                onClick = {
+                  if (choice.value == null) {
+                    choice.value = index
+                    if (index == 0) {
+                      onCorrect()
                     } else {
-                      MaterialTheme.colorScheme.onSurface
+                      onIncorrect()
                     }
-                ElevatedCard(
-                    modifier = Modifier.fillMaxWidth(0.7f).padding(10.dp),
-                    onClick = {
-                      if (choice.value == null) {
-                        choice.value = index
-                        if (index == 0) {
-                          onCorrect()
-                        } else {
-                          onIncorrect()
-                        }
-                      }
-                    },
-                    elevation =
-                        if (choice.value == index)
-                            CardDefaults.elevatedCardElevation(defaultElevation = 4.dp)
-                        else CardDefaults.elevatedCardElevation(defaultElevation = 2.dp)) {
-                      Row(
-                          modifier = Modifier.fillMaxWidth().padding(5.dp),
-                          horizontalArrangement = Arrangement.spacedBy(10.dp),
-                          verticalAlignment = Alignment.CenterVertically) {
-                            AnimatedContent(choice.value?.let { index == 0 }, label = "") {
-                              when (it) {
-                                null ->
-                                    Icon(
-                                        imageVector = Icons.Default.CheckBoxOutlineBlank,
-                                        contentDescription = null,
-                                        tint = color.value,
-                                        modifier = Modifier.padding(5.dp))
-                                true ->
-                                    Icon(
-                                        imageVector = Icons.Default.Check,
-                                        contentDescription = null,
-                                        tint = color.value,
-                                        modifier = Modifier.padding(5.dp))
-                                false ->
-                                    Icon(
-                                        imageVector = Icons.Default.Close,
-                                        contentDescription = null,
-                                        tint = color.value,
-                                        modifier = Modifier.padding(5.dp))
-                              }
-                            }
-                            Text(
-                                backs[index],
-                                style = Typography.bodyMedium,
-                                color = color.value,
-                                modifier = Modifier.testTag("flashcardBack--${flashcard.id}"))
+                  }
+                },
+                elevation =
+                    if (choice.value == index)
+                        CardDefaults.elevatedCardElevation(defaultElevation = 4.dp)
+                    else CardDefaults.elevatedCardElevation(defaultElevation = 2.dp)) {
+                  Row(
+                      modifier = Modifier.fillMaxWidth().padding(5.dp),
+                      horizontalArrangement = Arrangement.spacedBy(10.dp),
+                      verticalAlignment = Alignment.CenterVertically) {
+                        AnimatedContent(choice.value?.let { index == 0 }, label = "") {
+                          when (it) {
+                            null ->
+                                Icon(
+                                    imageVector = Icons.Default.CheckBoxOutlineBlank,
+                                    contentDescription = null,
+                                    tint = color.value,
+                                    modifier = Modifier.padding(5.dp))
+                            true ->
+                                Icon(
+                                    imageVector = Icons.Default.Check,
+                                    contentDescription = null,
+                                    tint = color.value,
+                                    modifier = Modifier.padding(5.dp))
+                            false ->
+                                Icon(
+                                    imageVector = Icons.Default.Close,
+                                    contentDescription = null,
+                                    tint = color.value,
+                                    modifier = Modifier.padding(5.dp))
                           }
-                    }
-              }
-            }
-      }
+                        }
+                        Text(
+                            backs[index],
+                            style = Typography.bodyMedium,
+                            color = color.value,
+                            modifier = Modifier.testTag("flashcardBack--${flashcard.id}"))
+                      }
+                }
+          }
+        }
+  }
 }
 
 @Composable

--- a/app/src/main/java/com/github/onlynotesswent/ui/common/ProfilePictureComposables.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/common/ProfilePictureComposables.kt
@@ -29,12 +29,25 @@ import com.github.onlynotesswent.model.user.User
  * Extracts the UID from the URI.
  *
  * @param uri The URI from which the UID is to be extracted.
+ * @param extension The extension of the file in the URI.
  * @return The UID extracted from the URI.
  */
-fun extractUID(uri: String?): String? {
+fun extractUID(uri: String?, extension:String = FileType.FLASHCARD_IMAGE.fileExtension): String? {
   val parts = uri?.split("/") ?: return null
   val fileName = parts.lastOrNull() ?: return null
-  return fileName.substringBeforeLast(".jpg")
+  return fileName.substringBeforeLast(extension)
+}
+
+/**
+ * Compares the UID extracted from the URI with the given UID.
+ *
+ * @param uri The URI from which the UID is to be extracted.
+ * @param uid The UID to compare with the extracted UID.
+ * @param extension The extension of the file in the URI.
+ * @return True if the extracted UID matches the given UID, false otherwise.
+ */
+fun compareUID(uri: String?, uid: String?, extension: String = FileType.FLASHCARD_IMAGE.fileExtension): Boolean {
+  return uid?.let { extractUID(uri, extension)?.take(it.length) == it } == true
 }
 
 private val doesNothing = {}

--- a/app/src/main/java/com/github/onlynotesswent/ui/common/ProfilePictureComposables.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/common/ProfilePictureComposables.kt
@@ -25,6 +25,18 @@ import com.github.onlynotesswent.model.file.FileType
 import com.github.onlynotesswent.model.file.FileViewModel
 import com.github.onlynotesswent.model.user.User
 
+/**
+ * Extracts the UID from the URI.
+ *
+ * @param uri The URI from which the UID is to be extracted.
+ * @return The UID extracted from the URI.
+ */
+fun extractUID(uri: String?): String? {
+  val parts = uri?.split("/") ?: return null
+  val fileName = parts.lastOrNull() ?: return null
+  return fileName.substringBeforeLast(".jpg")
+}
+
 private val doesNothing = {}
 /**
  * Displays the user's thumbnail profile picture, by wrapping the NonModifiableProfilePicture

--- a/app/src/main/java/com/github/onlynotesswent/ui/common/ProfilePictureComposables.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/common/ProfilePictureComposables.kt
@@ -32,7 +32,7 @@ import com.github.onlynotesswent.model.user.User
  * @param extension The extension of the file in the URI.
  * @return The UID extracted from the URI.
  */
-fun extractUID(uri: String?, extension:String = FileType.FLASHCARD_IMAGE.fileExtension): String? {
+fun extractUID(uri: String?, extension: String = FileType.FLASHCARD_IMAGE.fileExtension): String? {
   val parts = uri?.split("/") ?: return null
   val fileName = parts.lastOrNull() ?: return null
   return fileName.substringBeforeLast(extension)
@@ -46,7 +46,11 @@ fun extractUID(uri: String?, extension:String = FileType.FLASHCARD_IMAGE.fileExt
  * @param extension The extension of the file in the URI.
  * @return True if the extracted UID matches the given UID, false otherwise.
  */
-fun compareUID(uri: String?, uid: String?, extension: String = FileType.FLASHCARD_IMAGE.fileExtension): Boolean {
+fun compareUID(
+    uri: String?,
+    uid: String?,
+    extension: String = FileType.FLASHCARD_IMAGE.fileExtension
+): Boolean {
   return uid?.let { extractUID(uri, extension)?.take(it.length) == it } == true
 }
 

--- a/app/src/main/java/com/github/onlynotesswent/ui/deck/DeckMenu.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/deck/DeckMenu.kt
@@ -241,8 +241,11 @@ fun DeckScreen(
                     verticalArrangement = Arrangement.spacedBy(10.dp),
                     horizontalAlignment = Alignment.CenterHorizontally) {
                       items(sortedFlashcards.value.size) { index ->
+                        val flashcardState = remember {
+                          derivedStateOf { sortedFlashcards.value[index] }
+                        }
                         FlashcardViewItem(
-                            flashcard = sortedFlashcards.value[index],
+                            flashcard = flashcardState,
                             deckViewModel = deckViewModel,
                             flashcardViewModel = flashcardViewModel,
                             fileViewModel = fileViewModel,

--- a/app/src/main/java/com/github/onlynotesswent/ui/deck/DeckPlay.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/deck/DeckPlay.kt
@@ -4,11 +4,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
@@ -33,24 +30,17 @@ fun DeckPlayScreen(
   deckState.value?.let { deck -> flashcardViewModel.fetchFlashcardsFromDeck(deck) }
 
   val flashcards = flashcardViewModel.deckFlashcards.collectAsState().value
-
   val pagerState = rememberPagerState { flashcards.size }
 
-    HorizontalPager(pagerState) { pageIndex ->
-        Column(
-            modifier = Modifier.fillMaxWidth().padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            FlashcardPlayItem(
-                flashcard = flashcards[pageIndex],
-                userViewModel = userViewModel,
-                deckViewModel = deckViewModel,
-                flashcardViewModel = flashcardViewModel,
-                fileViewModel = fileViewModel,
-            )
+  HorizontalPager(pagerState) { pageIndex ->
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)) {
+          FlashcardPlayItem(
+              flashcard = flashcards[pageIndex],
+              fileViewModel = fileViewModel,
+          )
         }
-
-    }
-
+  }
 }

--- a/app/src/main/java/com/github/onlynotesswent/ui/deck/DeckPlay.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/deck/DeckPlay.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -31,14 +33,14 @@ fun DeckPlayScreen(
 
   val flashcards = flashcardViewModel.deckFlashcards.collectAsState().value
   val pagerState = rememberPagerState { flashcards.size }
-
   HorizontalPager(pagerState) { pageIndex ->
     Column(
         modifier = Modifier.fillMaxWidth().padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(16.dp)) {
+          val flashcardState = remember { derivedStateOf { flashcards[pageIndex] } }
           FlashcardPlayItem(
-              flashcard = flashcards[pageIndex],
+              flashcard = flashcardState,
               fileViewModel = fileViewModel,
           )
         }

--- a/app/src/main/java/com/github/onlynotesswent/ui/deck/DeckPlay.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/deck/DeckPlay.kt
@@ -2,15 +2,55 @@ package com.github.onlynotesswent.ui.deck
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.github.onlynotesswent.model.file.FileViewModel
+import com.github.onlynotesswent.model.flashcard.FlashcardViewModel
+import com.github.onlynotesswent.model.flashcard.deck.DeckViewModel
+import com.github.onlynotesswent.model.user.UserViewModel
+import com.github.onlynotesswent.ui.common.FlashcardPlayItem
+import com.github.onlynotesswent.ui.navigation.NavigationActions
 
 @Composable
-fun DeckPlayScreen() {
-  Column(
-      verticalArrangement = Arrangement.Center,
-      horizontalAlignment = Alignment.CenterHorizontally) {
-        Text("To Be Implemented")
-      }
+fun DeckPlayScreen(
+    navigationActions: NavigationActions,
+    userViewModel: UserViewModel,
+    deckViewModel: DeckViewModel,
+    flashcardViewModel: FlashcardViewModel,
+    fileViewModel: FileViewModel
+) {
+  val deckState = deckViewModel.selectedDeck.collectAsState()
+  deckState.value?.let { deck -> flashcardViewModel.fetchFlashcardsFromDeck(deck) }
+
+  val flashcards = flashcardViewModel.deckFlashcards.collectAsState().value
+
+  val pagerState = rememberPagerState { flashcards.size }
+
+    HorizontalPager(pagerState) { pageIndex ->
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            FlashcardPlayItem(
+                flashcard = flashcards[pageIndex],
+                userViewModel = userViewModel,
+                deckViewModel = deckViewModel,
+                flashcardViewModel = flashcardViewModel,
+                fileViewModel = fileViewModel,
+            )
+        }
+
+    }
+
 }

--- a/app/src/main/java/com/github/onlynotesswent/ui/deck/DeckPlay.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/deck/DeckPlay.kt
@@ -39,10 +39,7 @@ fun DeckPlayScreen(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(16.dp)) {
           val flashcardState = remember { derivedStateOf { flashcards[pageIndex] } }
-          FlashcardPlayItem(
-              flashcard = flashcardState,
-              fileViewModel = fileViewModel,
-          )
+          FlashcardPlayItem(flashcardState, fileViewModel)
         }
   }
 }


### PR DESCRIPTION
# Description

I have created flash card composables for MCQs and flippable flashcards, in `FlashcardComposables.kt`. I have also improved previous flashcard ui code (view items, dialog), to use some new modularised method I created.

I have also fixed the image not up to date problem by comparing the temp file's name with the flashcard uid. I will make a small pr to address this fix in all other places (user thumbnails mostly). 

Fixes #214 

## **Preview:**
### MCQ previews: _blank MCQ | correct answer selected | wrong answer selected_

<img width="323" alt="Screenshot 2024-12-16 at 16 09 01" src="https://github.com/user-attachments/assets/2b50a3d4-0011-4789-9751-f5494496817a" />
<img width="324" alt="Screenshot 2024-12-16 at 16 09 11" src="https://github.com/user-attachments/assets/ce280494-5806-438f-8bc8-cf7191422e56" />
<img width="306" alt="Screenshot 2024-12-16 at 16 09 29" src="https://github.com/user-attachments/assets/90bcbd76-4be8-4939-b02d-64ae96795f7a" />


### Animations:

[Screen_recording_20241216_161013.webm](https://github.com/user-attachments/assets/8d6f28ad-935d-4ae0-8374-7dc33744ea0f)
[Screen_recording_20241216_160949.webm](https://github.com/user-attachments/assets/9c647e8b-7210-4c00-88f1-95d3c4b4a1d6)




# How Has This Been Tested?

I have created a new basic test `DeckPlayTest.kt` which for now only composes and tests the flashcard items. @LawrenceLeitgib will then complete with all tests for the finished Deck Play screen.
 
### Unit Tests

None added
  
### UI Tests

Created `DeckPlayTest.kt`, modified `DeckMenuTest.kt` to be up to date with new methods.

### End to end Tests

None added

 
# Dependencies

None added

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged in downstream modules, no conflicts with main
