### PR TITLE
Bugfix/cache display bug

### DIFF
--- a/app/src/main/java/com/github/onlynotesswent/model/cache/FolderDao.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/cache/FolderDao.kt
@@ -10,12 +10,15 @@ import com.github.onlynotesswent.model.folder.Folder
 interface FolderDao {
   @Query("SELECT * FROM folder WHERE id = :folderId") fun getFolderById(folderId: String): Folder?
 
-  @Query("SELECT * FROM folder WHERE userId = :userId") fun getFoldersFromUserId(userId: String): List<Folder>
+  @Query("SELECT * FROM folder WHERE userId = :userId")
+  fun getFoldersFromUserId(userId: String): List<Folder>
 
-  @Query("SELECT * FROM folder WHERE parentFolderId IS NULL AND isDeckFolder = 0 AND userId = :userId")
+  @Query(
+      "SELECT * FROM folder WHERE parentFolderId IS NULL AND isDeckFolder = 0 AND userId = :userId")
   fun getRootNoteFoldersFromUserId(userId: String): List<Folder>
 
-  @Query("SELECT * FROM folder WHERE parentFolderId IS NULL AND isDeckFolder = 1 AND userId = :userId")
+  @Query(
+      "SELECT * FROM folder WHERE parentFolderId IS NULL AND isDeckFolder = 1 AND userId = :userId")
   fun getRootDeckFoldersFromUserId(userId: String): List<Folder>
 
   @Query("SELECT * FROM folder WHERE name = :folderName AND isDeckFolder = 1")

--- a/app/src/main/java/com/github/onlynotesswent/model/cache/FolderDao.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/cache/FolderDao.kt
@@ -10,13 +10,13 @@ import com.github.onlynotesswent.model.folder.Folder
 interface FolderDao {
   @Query("SELECT * FROM folder WHERE id = :folderId") fun getFolderById(folderId: String): Folder?
 
-  @Query("SELECT * FROM folder") fun getFoldersFromUserId(): List<Folder>
+  @Query("SELECT * FROM folder WHERE userId = :userId") fun getFoldersFromUserId(userId: String): List<Folder>
 
-  @Query("SELECT * FROM folder WHERE parentFolderId IS NULL AND isDeckFolder = 0")
-  fun getRootNoteFoldersFromUserId(): List<Folder>
+  @Query("SELECT * FROM folder WHERE parentFolderId IS NULL AND isDeckFolder = 0 AND userId = :userId")
+  fun getRootNoteFoldersFromUserId(userId: String): List<Folder>
 
-  @Query("SELECT * FROM folder WHERE parentFolderId IS NULL AND isDeckFolder = 1")
-  fun getRootDeckFoldersFromUserId(): List<Folder>
+  @Query("SELECT * FROM folder WHERE parentFolderId IS NULL AND isDeckFolder = 1 AND userId = :userId")
+  fun getRootDeckFoldersFromUserId(userId: String): List<Folder>
 
   @Query("SELECT * FROM folder WHERE name = :folderName AND isDeckFolder = 1")
   fun getDeckFolderByName(folderName: String): List<Folder>
@@ -30,5 +30,5 @@ interface FolderDao {
 
   @Query("DELETE FROM folder WHERE id = :folderId") fun deleteFolderById(folderId: String)
 
-  @Query("DELETE FROM folder") fun deleteFoldersFromUid()
+  @Query("DELETE FROM folder WHERE userId = :userId") fun deleteFoldersFromUid(userId: String)
 }

--- a/app/src/main/java/com/github/onlynotesswent/model/cache/NoteDao.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/cache/NoteDao.kt
@@ -10,9 +10,9 @@ import com.github.onlynotesswent.model.note.Note
 interface NoteDao {
   @Query("SELECT * FROM note WHERE id = :noteId") fun getNoteById(noteId: String): Note?
 
-  @Query("SELECT * FROM note") fun getNotesFromUid(): List<Note>
+  @Query("SELECT * FROM note WHERE userid = :userId") fun getNotesFromUid(userId: String): List<Note>
 
-  @Query("SELECT * FROM note WHERE folderid IS NULL") fun getRootNotesFromUid(): List<Note>
+  @Query("SELECT * FROM note WHERE folderid IS NULL AND userid = :userId") fun getRootNotesFromUid(userId: String): List<Note>
 
   @Query("SELECT * FROM note WHERE folderid = :folderId")
   fun getNotesFromFolder(folderId: String): List<Note>
@@ -23,7 +23,7 @@ interface NoteDao {
 
   @Query("DELETE FROM note WHERE id = :noteId") fun deleteNoteById(noteId: String)
 
-  @Query("DELETE FROM note") fun deleteNotesFromUid()
+  @Query("DELETE FROM note WHERE userid = :userId") fun deleteNotesFromUid(userId: String)
 
   @Query("DELETE FROM note WHERE folderid = :folderId") fun deleteNotesFromFolder(folderId: String)
 }

--- a/app/src/main/java/com/github/onlynotesswent/model/cache/NoteDao.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/cache/NoteDao.kt
@@ -10,9 +10,11 @@ import com.github.onlynotesswent.model.note.Note
 interface NoteDao {
   @Query("SELECT * FROM note WHERE id = :noteId") fun getNoteById(noteId: String): Note?
 
-  @Query("SELECT * FROM note WHERE userid = :userId") fun getNotesFromUid(userId: String): List<Note>
+  @Query("SELECT * FROM note WHERE userid = :userId")
+  fun getNotesFromUid(userId: String): List<Note>
 
-  @Query("SELECT * FROM note WHERE folderid IS NULL AND userid = :userId") fun getRootNotesFromUid(userId: String): List<Note>
+  @Query("SELECT * FROM note WHERE folderid IS NULL AND userid = :userId")
+  fun getRootNotesFromUid(userId: String): List<Note>
 
   @Query("SELECT * FROM note WHERE folderid = :folderId")
   fun getNotesFromFolder(folderId: String): List<Note>

--- a/app/src/main/java/com/github/onlynotesswent/model/folder/FolderRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/folder/FolderRepositoryFirestore.kt
@@ -235,7 +235,8 @@ class FolderRepositoryFirestore(
   ) {
     try {
       val cachedFolders: List<Folder> =
-          if (useCache) withContext(Dispatchers.IO) { folderDao.getRootNoteFoldersFromUserId(userId) }
+          if (useCache)
+              withContext(Dispatchers.IO) { folderDao.getRootNoteFoldersFromUserId(userId) }
           else emptyList()
 
       // If device is offline, fetch from local database
@@ -275,7 +276,8 @@ class FolderRepositoryFirestore(
   ) {
     try {
       val cachedFolders: List<Folder> =
-          if (useCache) withContext(Dispatchers.IO) { folderDao.getRootDeckFoldersFromUserId(userId) }
+          if (useCache)
+              withContext(Dispatchers.IO) { folderDao.getRootDeckFoldersFromUserId(userId) }
           else emptyList()
 
       // If device is offline, fetch from local database
@@ -317,7 +319,8 @@ class FolderRepositoryFirestore(
   ) {
     try {
       val cachedFolders: List<Folder> =
-          if (useCache) withContext(Dispatchers.IO) { folderDao.getRootDeckFoldersFromUserId(userId) }
+          if (useCache)
+              withContext(Dispatchers.IO) { folderDao.getRootDeckFoldersFromUserId(userId) }
           else emptyList()
 
       // If device is offline, fetch from local database

--- a/app/src/main/java/com/github/onlynotesswent/model/folder/FolderRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/folder/FolderRepositoryFirestore.kt
@@ -126,7 +126,7 @@ class FolderRepositoryFirestore(
   ) {
     // Update the cache if needed
     if (useCache) {
-      withContext(Dispatchers.IO) { folderDao.deleteFoldersFromUid() }
+      withContext(Dispatchers.IO) { folderDao.deleteFoldersFromUid(userId) }
     }
 
     db.collection(folderCollectionPath).get().addOnCompleteListener { task ->
@@ -195,7 +195,7 @@ class FolderRepositoryFirestore(
   ) {
     try {
       val cachedFolders: List<Folder> =
-          if (useCache) withContext(Dispatchers.IO) { folderDao.getFoldersFromUserId() }
+          if (useCache) withContext(Dispatchers.IO) { folderDao.getFoldersFromUserId(userId) }
           else emptyList()
 
       // If device is offline, fetch from local database
@@ -235,7 +235,7 @@ class FolderRepositoryFirestore(
   ) {
     try {
       val cachedFolders: List<Folder> =
-          if (useCache) withContext(Dispatchers.IO) { folderDao.getRootNoteFoldersFromUserId() }
+          if (useCache) withContext(Dispatchers.IO) { folderDao.getRootNoteFoldersFromUserId(userId) }
           else emptyList()
 
       // If device is offline, fetch from local database
@@ -275,7 +275,7 @@ class FolderRepositoryFirestore(
   ) {
     try {
       val cachedFolders: List<Folder> =
-          if (useCache) withContext(Dispatchers.IO) { folderDao.getRootDeckFoldersFromUserId() }
+          if (useCache) withContext(Dispatchers.IO) { folderDao.getRootDeckFoldersFromUserId(userId) }
           else emptyList()
 
       // If device is offline, fetch from local database
@@ -317,12 +317,11 @@ class FolderRepositoryFirestore(
   ) {
     try {
       val cachedFolders: List<Folder> =
-          if (useCache) withContext(Dispatchers.IO) { folderDao.getRootDeckFoldersFromUserId() }
+          if (useCache) withContext(Dispatchers.IO) { folderDao.getRootDeckFoldersFromUserId(userId) }
           else emptyList()
 
       // If device is offline, fetch from local database
       if (!NetworkUtils.isInternetAvailable(context)) {
-        println("isInternetAvailable: ${NetworkUtils.isInternetAvailable(context)}")
         if (cachedFolders.isEmpty()) {
           onFolderNotFound()
           return

--- a/app/src/main/java/com/github/onlynotesswent/model/folder/FolderRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/folder/FolderRepositoryFirestore.kt
@@ -10,6 +10,7 @@ import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -19,7 +20,8 @@ import kotlinx.coroutines.withContext
 class FolderRepositoryFirestore(
     private val db: FirebaseFirestore,
     private val cache: CacheDatabase,
-    private val context: Context
+    private val context: Context,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : FolderRepository {
 
   private val folderCollectionPath = "folders"
@@ -50,7 +52,7 @@ class FolderRepositoryFirestore(
   ) {
     // Update the cache if needed
     if (useCache) {
-      withContext(Dispatchers.IO) { folderDao.addFolder(folder) }
+      withContext(dispatcher) { folderDao.addFolder(folder) }
     }
 
     db.collection(folderCollectionPath).document(folder.id).set(folder).addOnCompleteListener {
@@ -74,7 +76,7 @@ class FolderRepositoryFirestore(
   ) {
     // Update the cache if needed
     if (useCache) {
-      withContext(Dispatchers.IO) { folderDao.addFolders(folders) }
+      withContext(dispatcher) { folderDao.addFolders(folders) }
     }
 
     val batch = db.batch()
@@ -102,7 +104,7 @@ class FolderRepositoryFirestore(
   ) {
     // Update the cache if needed
     if (useCache) {
-      withContext(Dispatchers.IO) { folderDao.deleteFolderById(folderId) }
+      withContext(dispatcher) { folderDao.deleteFolderById(folderId) }
     }
 
     db.collection(folderCollectionPath).document(folderId).delete().addOnCompleteListener { result
@@ -126,7 +128,7 @@ class FolderRepositoryFirestore(
   ) {
     // Update the cache if needed
     if (useCache) {
-      withContext(Dispatchers.IO) { folderDao.deleteFoldersFromUid(userId) }
+      withContext(dispatcher) { folderDao.deleteFoldersFromUid(userId) }
     }
 
     db.collection(folderCollectionPath).get().addOnCompleteListener { task ->
@@ -156,7 +158,7 @@ class FolderRepositoryFirestore(
   ) {
     try {
       val cachedFolder: Folder? =
-          if (useCache) withContext(Dispatchers.IO) { folderDao.getFolderById(folderId) } else null
+          if (useCache) withContext(dispatcher) { folderDao.getFolderById(folderId) } else null
 
       // If device is offline, fetch from local database
       if (!NetworkUtils.isInternetAvailable(context)) {
@@ -169,7 +171,7 @@ class FolderRepositoryFirestore(
 
       // If device is online, fetch from Firestore
       val firestoreFolder =
-          withContext(Dispatchers.IO) {
+          withContext(dispatcher) {
             db.collection(folderCollectionPath).document(folderId).get().await().let {
               documentSnapshotToFolder(it)
             }
@@ -195,7 +197,7 @@ class FolderRepositoryFirestore(
   ) {
     try {
       val cachedFolders: List<Folder> =
-          if (useCache) withContext(Dispatchers.IO) { folderDao.getFoldersFromUserId(userId) }
+          if (useCache) withContext(dispatcher) { folderDao.getFoldersFromUserId(userId) }
           else emptyList()
 
       // If device is offline, fetch from local database
@@ -206,7 +208,7 @@ class FolderRepositoryFirestore(
 
       // If device is online, fetch from Firestore
       val firestoreFolders =
-          withContext(Dispatchers.IO) {
+          withContext(dispatcher) {
             db.collection(folderCollectionPath)
                 .get()
                 .await()
@@ -235,8 +237,7 @@ class FolderRepositoryFirestore(
   ) {
     try {
       val cachedFolders: List<Folder> =
-          if (useCache)
-              withContext(Dispatchers.IO) { folderDao.getRootNoteFoldersFromUserId(userId) }
+          if (useCache) withContext(dispatcher) { folderDao.getRootNoteFoldersFromUserId(userId) }
           else emptyList()
 
       // If device is offline, fetch from local database
@@ -247,7 +248,7 @@ class FolderRepositoryFirestore(
 
       // If device is online, fetch from Firestore
       val firestoreFolders =
-          withContext(Dispatchers.IO) {
+          withContext(dispatcher) {
             db.collection(folderCollectionPath)
                 .get()
                 .await()
@@ -276,8 +277,7 @@ class FolderRepositoryFirestore(
   ) {
     try {
       val cachedFolders: List<Folder> =
-          if (useCache)
-              withContext(Dispatchers.IO) { folderDao.getRootDeckFoldersFromUserId(userId) }
+          if (useCache) withContext(dispatcher) { folderDao.getRootDeckFoldersFromUserId(userId) }
           else emptyList()
 
       // If device is offline, fetch from local database
@@ -288,7 +288,7 @@ class FolderRepositoryFirestore(
 
       // If device is online, fetch from Firestore
       val firestoreFolders =
-          withContext(Dispatchers.IO) {
+          withContext(dispatcher) {
             db.collection(folderCollectionPath)
                 .get()
                 .await()
@@ -319,8 +319,7 @@ class FolderRepositoryFirestore(
   ) {
     try {
       val cachedFolders: List<Folder> =
-          if (useCache)
-              withContext(Dispatchers.IO) { folderDao.getRootDeckFoldersFromUserId(userId) }
+          if (useCache) withContext(dispatcher) { folderDao.getRootDeckFoldersFromUserId(userId) }
           else emptyList()
 
       // If device is offline, fetch from local database
@@ -335,7 +334,7 @@ class FolderRepositoryFirestore(
 
       // If device is online, fetch from Firestore
       val firestoreFolders =
-          withContext(Dispatchers.IO) {
+          withContext(dispatcher) {
             db.collection(folderCollectionPath)
                 .get()
                 .await()
@@ -368,7 +367,7 @@ class FolderRepositoryFirestore(
   ) {
     // Update the cache if needed
     if (useCache) {
-      withContext(Dispatchers.IO) { folderDao.addFolder(folder) }
+      withContext(dispatcher) { folderDao.addFolder(folder) }
     }
 
     db.collection(folderCollectionPath).document(folder.id).set(folder).addOnCompleteListener {
@@ -392,7 +391,7 @@ class FolderRepositoryFirestore(
   ) {
     try {
       val cachedFolders: List<Folder> =
-          if (useCache) withContext(Dispatchers.IO) { folderDao.getSubfoldersOf(parentFolderId) }
+          if (useCache) withContext(dispatcher) { folderDao.getSubfoldersOf(parentFolderId) }
           else emptyList()
 
       // If device is offline, fetch from local database
@@ -403,7 +402,7 @@ class FolderRepositoryFirestore(
 
       // If device is online, fetch from Firestore
       val firestoreFolders =
-          withContext(Dispatchers.IO) {
+          withContext(dispatcher) {
             db.collection(folderCollectionPath)
                 .get()
                 .await()
@@ -479,7 +478,7 @@ class FolderRepositoryFirestore(
         parentFolderId = folder.id,
         onSuccess = { subFolders ->
           subFolders.forEach { subFolder ->
-            CoroutineScope(Dispatchers.IO).launch {
+            CoroutineScope(dispatcher).launch {
               deleteFolderContents(
                   folder = subFolder,
                   noteViewModel = noteViewModel,

--- a/app/src/main/java/com/github/onlynotesswent/model/folder/FolderViewModel.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/folder/FolderViewModel.kt
@@ -404,7 +404,6 @@ class FolderViewModel(private val repository: FolderRepository) : ViewModel() {
    * @param onFailure The function to call when the folder fails to be updated.
    * @param useCache Whether to update data from cache. Should be true only if userId of the folder
    *   is the current user.
-   * @param isDeckView A flag indicating if the folder is a deck view.
    */
   fun updateFolderNoStateUpdate(
       folder: Folder,

--- a/app/src/main/java/com/github/onlynotesswent/model/folder/FolderViewModel.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/folder/FolderViewModel.kt
@@ -215,7 +215,7 @@ class FolderViewModel(private val repository: FolderRepository) : ViewModel() {
    * @param onSuccess The function to call when the root folders are retrieved successfully.
    * @param onFailure The function to call when the root folders fail to be retrieved.
    * @param useCache Whether to update data from cache. Should be true only if [userId] is the
-   *  current user.
+   *   current user.
    */
   fun getRootFoldersFromUserId(
       userId: String,
@@ -238,7 +238,7 @@ class FolderViewModel(private val repository: FolderRepository) : ViewModel() {
    * @param onSuccess The function to call when the root folders are retrieved successfully.
    * @param onFailure The function to call when the root folders fail to be retrieved.
    * @param useCache Whether to update data from cache. Should be true only if [userId] is the
-   *  current user.
+   *   current user.
    */
   fun getRootNoteFoldersFromUserId(
       userId: String,
@@ -294,7 +294,7 @@ class FolderViewModel(private val repository: FolderRepository) : ViewModel() {
    * @param onSuccess The function to call when the folders are retrieved successfully.
    * @param onFailure The function to call when the folder fails to be retrieved.
    * @param useCache Whether to update data from cache. Should be true only if userId of the folder
-   *  is the current user.
+   *   is the current user.
    */
   fun getDeckFoldersByName(
       name: String,
@@ -452,8 +452,8 @@ class FolderViewModel(private val repository: FolderRepository) : ViewModel() {
    * @param onSuccess A callback that receives a list of `Folder` objects on successful retrieval.
    * @param onFailure A callback that receives an `Exception` in case of a failure. Defaults to an
    *   empty lambda if not provided.
-   *  @param useCache Whether to update data from cache. Should be true only if userId of the folder
-   *   is the current user.
+   *     @param useCache Whether to update data from cache. Should be true only if userId of the
+   *       folder is the current user.
    */
   fun getSubFoldersOfNoStateUpdate(
       parentFolderId: String,

--- a/app/src/main/java/com/github/onlynotesswent/model/folder/FolderViewModel.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/folder/FolderViewModel.kt
@@ -214,17 +214,20 @@ class FolderViewModel(private val repository: FolderRepository) : ViewModel() {
    * @param isDeckView A flag indicating if the folder is a deck view.
    * @param onSuccess The function to call when the root folders are retrieved successfully.
    * @param onFailure The function to call when the root folders fail to be retrieved.
+   * @param useCache Whether to update data from cache. Should be true only if [userId] is the
+   *  current user.
    */
   fun getRootFoldersFromUserId(
       userId: String,
       isDeckView: Boolean = false,
       onSuccess: (List<Folder>) -> Unit = {},
       onFailure: (Exception) -> Unit = {},
+      useCache: Boolean = false
   ) {
     if (isDeckView) {
-      getRootDeckFoldersFromUserId(userId, onSuccess, onFailure)
+      getRootDeckFoldersFromUserId(userId, onSuccess, onFailure, useCache)
     } else {
-      getRootNoteFoldersFromUserId(userId, onSuccess, onFailure)
+      getRootNoteFoldersFromUserId(userId, onSuccess, onFailure, useCache)
     }
   }
 
@@ -235,6 +238,7 @@ class FolderViewModel(private val repository: FolderRepository) : ViewModel() {
    * @param onSuccess The function to call when the root folders are retrieved successfully.
    * @param onFailure The function to call when the root folders fail to be retrieved.
    * @param useCache Whether to update data from cache. Should be true only if [userId] is the
+   *  current user.
    */
   fun getRootNoteFoldersFromUserId(
       userId: String,
@@ -289,6 +293,8 @@ class FolderViewModel(private val repository: FolderRepository) : ViewModel() {
    * @param onFolderNotFound The function to call when the folder is not found.
    * @param onSuccess The function to call when the folders are retrieved successfully.
    * @param onFailure The function to call when the folder fails to be retrieved.
+   * @param useCache Whether to update data from cache. Should be true only if userId of the folder
+   *  is the current user.
    */
   fun getDeckFoldersByName(
       name: String,
@@ -446,6 +452,8 @@ class FolderViewModel(private val repository: FolderRepository) : ViewModel() {
    * @param onSuccess A callback that receives a list of `Folder` objects on successful retrieval.
    * @param onFailure A callback that receives an `Exception` in case of a failure. Defaults to an
    *   empty lambda if not provided.
+   *  @param useCache Whether to update data from cache. Should be true only if userId of the folder
+   *   is the current user.
    */
   fun getSubFoldersOfNoStateUpdate(
       parentFolderId: String,

--- a/app/src/main/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestore.kt
@@ -108,7 +108,8 @@ class NoteRepositoryFirestore(
   ) {
     try {
       val cachedNotes: List<Note> =
-          if (useCache) withContext(Dispatchers.IO) { noteDao.getNotesFromUid(userId) } else emptyList()
+          if (useCache) withContext(Dispatchers.IO) { noteDao.getNotesFromUid(userId) }
+          else emptyList()
 
       // If device is offline, fetch from from local database
       if (!NetworkUtils.isInternetAvailable(context)) {

--- a/app/src/main/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestore.kt
@@ -12,6 +12,7 @@ import com.google.firebase.Timestamp
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
@@ -19,7 +20,8 @@ import kotlinx.coroutines.withContext
 class NoteRepositoryFirestore(
     private val db: FirebaseFirestore,
     private val cache: CacheDatabase,
-    private val context: Context
+    private val context: Context,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : NoteRepository {
 
   private val collectionPath = "notes"
@@ -108,8 +110,7 @@ class NoteRepositoryFirestore(
   ) {
     try {
       val cachedNotes: List<Note> =
-          if (useCache) withContext(Dispatchers.IO) { noteDao.getNotesFromUid(userId) }
-          else emptyList()
+          if (useCache) withContext(dispatcher) { noteDao.getNotesFromUid(userId) } else emptyList()
 
       // If device is offline, fetch from from local database
       if (!NetworkUtils.isInternetAvailable(context)) {
@@ -119,7 +120,7 @@ class NoteRepositoryFirestore(
 
       // If device is online, fetch from Firestore
       val firestoreNotes =
-          withContext(Dispatchers.IO) {
+          withContext(dispatcher) {
             db.collection(collectionPath)
                 .get()
                 .await()
@@ -147,7 +148,7 @@ class NoteRepositoryFirestore(
   ) {
     try {
       val cachedNotes: List<Note> =
-          if (useCache) withContext(Dispatchers.IO) { noteDao.getRootNotesFromUid(userId) }
+          if (useCache) withContext(dispatcher) { noteDao.getRootNotesFromUid(userId) }
           else emptyList()
 
       // If device is offline, fetch from local database
@@ -158,7 +159,7 @@ class NoteRepositoryFirestore(
 
       // If device is online, fetch from Firestore
       val firestoreNotes =
-          withContext(Dispatchers.IO) {
+          withContext(dispatcher) {
             db.collection(collectionPath)
                 .get()
                 .await()
@@ -186,7 +187,7 @@ class NoteRepositoryFirestore(
   ) {
     try {
       val cachedNote: Note? =
-          if (useCache) withContext(Dispatchers.IO) { noteDao.getNoteById(id) } else null
+          if (useCache) withContext(dispatcher) { noteDao.getNoteById(id) } else null
 
       // If device is offline, fetch from local database
       if (!NetworkUtils.isInternetAvailable(context)) {
@@ -199,7 +200,7 @@ class NoteRepositoryFirestore(
 
       // If device is online, fetch from Firestore
       val firestoreNote =
-          withContext(Dispatchers.IO) {
+          withContext(dispatcher) {
             db.collection(collectionPath).document(id).get().await().let {
               documentSnapshotToNote(it)
             }
@@ -224,7 +225,7 @@ class NoteRepositoryFirestore(
   ) {
     // Update the cache if needed
     if (useCache) {
-      withContext(Dispatchers.IO) { noteDao.addNote(note) }
+      withContext(dispatcher) { noteDao.addNote(note) }
     }
 
     performFirestoreOperation(
@@ -241,7 +242,7 @@ class NoteRepositoryFirestore(
   ) {
     // Update the cache if needed
     if (useCache) {
-      withContext(Dispatchers.IO) { noteDao.addNotes(notes) }
+      withContext(dispatcher) { noteDao.addNotes(notes) }
     }
 
     val batch = db.batch()
@@ -260,7 +261,7 @@ class NoteRepositoryFirestore(
   ) {
     // Update the cache if needed
     if (useCache) {
-      withContext(Dispatchers.IO) { noteDao.addNote(note) }
+      withContext(dispatcher) { noteDao.addNote(note) }
     }
 
     performFirestoreOperation(
@@ -277,7 +278,7 @@ class NoteRepositoryFirestore(
   ) {
     // Update the cache if needed
     if (useCache) {
-      withContext(Dispatchers.IO) { noteDao.deleteNoteById(id) }
+      withContext(dispatcher) { noteDao.deleteNoteById(id) }
     }
 
     performFirestoreOperation(
@@ -292,7 +293,7 @@ class NoteRepositoryFirestore(
   ) {
     // Update the cache if needed
     if (useCache) {
-      withContext(Dispatchers.IO) { noteDao.deleteNotesFromUid(userId) }
+      withContext(dispatcher) { noteDao.deleteNotesFromUid(userId) }
     }
 
     db.collection(collectionPath).get().addOnCompleteListener { task ->
@@ -320,7 +321,7 @@ class NoteRepositoryFirestore(
   ) {
     try {
       val cachedNotes: List<Note> =
-          if (useCache) withContext(Dispatchers.IO) { noteDao.getNotesFromFolder(folderId) }
+          if (useCache) withContext(dispatcher) { noteDao.getNotesFromFolder(folderId) }
           else emptyList()
 
       // If device is offline, fetch from local database
@@ -331,7 +332,7 @@ class NoteRepositoryFirestore(
 
       // If device is online, fetch from Firestore
       val firestoreNotes =
-          withContext(Dispatchers.IO) {
+          withContext(dispatcher) {
             db.collection(collectionPath)
                 .get()
                 .await()
@@ -359,7 +360,7 @@ class NoteRepositoryFirestore(
   ) {
     // Update the cache if needed
     if (useCache) {
-      withContext(Dispatchers.IO) { noteDao.deleteNotesFromFolder(folderId) }
+      withContext(dispatcher) { noteDao.deleteNotesFromFolder(folderId) }
     }
 
     db.collection(collectionPath).get().addOnCompleteListener { task ->

--- a/app/src/main/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/note/NoteRepositoryFirestore.kt
@@ -108,7 +108,7 @@ class NoteRepositoryFirestore(
   ) {
     try {
       val cachedNotes: List<Note> =
-          if (useCache) withContext(Dispatchers.IO) { noteDao.getNotesFromUid() } else emptyList()
+          if (useCache) withContext(Dispatchers.IO) { noteDao.getNotesFromUid(userId) } else emptyList()
 
       // If device is offline, fetch from from local database
       if (!NetworkUtils.isInternetAvailable(context)) {
@@ -146,7 +146,7 @@ class NoteRepositoryFirestore(
   ) {
     try {
       val cachedNotes: List<Note> =
-          if (useCache) withContext(Dispatchers.IO) { noteDao.getRootNotesFromUid() }
+          if (useCache) withContext(Dispatchers.IO) { noteDao.getRootNotesFromUid(userId) }
           else emptyList()
 
       // If device is offline, fetch from local database
@@ -291,7 +291,7 @@ class NoteRepositoryFirestore(
   ) {
     // Update the cache if needed
     if (useCache) {
-      withContext(Dispatchers.IO) { noteDao.deleteNotesFromUid() }
+      withContext(Dispatchers.IO) { noteDao.deleteNotesFromUid(userId) }
     }
 
     db.collection(collectionPath).get().addOnCompleteListener { task ->


### PR DESCRIPTION
# Description

This PR resolves a bug where notes and folders belonging to other users would incorrectly appear when the app was accessed on the same device using multiple accounts. The issue occurred because the cache database stored notes and folders from all accounts accessed on the device, but the retrieval methods did not have proper filtering by userId. This fix ensures that only the authenticated user's notes and folders are displayed.

Fixes #236 

# How Has This Been Tested?

No tests needed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged in downstream modules, no conflicts with main
