### PR TITLE
Feature: save deck copies locally

### DIFF
--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/deck/DeckMenuTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/deck/DeckMenuTest.kt
@@ -21,6 +21,8 @@ import com.github.onlynotesswent.model.file.FileViewModel
 import com.github.onlynotesswent.model.flashcard.Flashcard
 import com.github.onlynotesswent.model.flashcard.FlashcardRepository
 import com.github.onlynotesswent.model.flashcard.FlashcardViewModel
+import com.github.onlynotesswent.model.folder.FolderRepository
+import com.github.onlynotesswent.model.folder.FolderViewModel
 import com.github.onlynotesswent.model.user.User
 import com.github.onlynotesswent.model.user.UserRepository
 import com.github.onlynotesswent.model.user.UserViewModel
@@ -48,6 +50,7 @@ class DeckMenuTest {
   @Mock private lateinit var mockFlashcardRepository: FlashcardRepository
   @Mock private lateinit var mockUserRepository: UserRepository
   @Mock private lateinit var mockFileRepository: FileRepository
+  @Mock private lateinit var mockFolderRepository: FolderRepository
   @Mock private lateinit var navigationActions: NavigationActions
   @Mock private lateinit var pictureTaker: PictureTaker
 
@@ -55,6 +58,7 @@ class DeckMenuTest {
   private lateinit var flashcardViewModel: FlashcardViewModel
   private lateinit var userViewModel: UserViewModel
   private lateinit var fileViewModel: FileViewModel
+  private lateinit var folderViewModel: FolderViewModel
 
   private val testUser = User("First Name", "Last Name", "Username", "testUserId", "testEmail")
 
@@ -108,6 +112,7 @@ class DeckMenuTest {
     flashcardViewModel = FlashcardViewModel(mockFlashcardRepository)
     userViewModel = UserViewModel(mockUserRepository)
     fileViewModel = FileViewModel(mockFileRepository)
+    folderViewModel = FolderViewModel(mockFolderRepository)
 
     // Mock the current route to be the deck screen
     `when`(navigationActions.currentRoute())
@@ -169,6 +174,7 @@ class DeckMenuTest {
           flashcardViewModel = flashcardViewModel,
           userViewModel = userViewModel,
           fileViewModel = fileViewModel,
+          folderViewModel = folderViewModel,
           navigationActions = navigationActions,
           pictureTaker = pictureTaker,
       )
@@ -225,6 +231,7 @@ class DeckMenuTest {
           flashcardViewModel = flashcardViewModel,
           userViewModel = userViewModel,
           fileViewModel = fileViewModel,
+          folderViewModel = folderViewModel,
           navigationActions = navigationActions,
           pictureTaker = pictureTaker,
       )
@@ -260,6 +267,7 @@ class DeckMenuTest {
           flashcardViewModel = flashcardViewModel,
           userViewModel = userViewModel,
           fileViewModel = fileViewModel,
+          folderViewModel = folderViewModel,
           navigationActions = navigationActions,
           pictureTaker = pictureTaker,
       )
@@ -357,6 +365,7 @@ class DeckMenuTest {
           flashcardViewModel = flashcardViewModel,
           userViewModel = userViewModel,
           fileViewModel = fileViewModel,
+          folderViewModel = folderViewModel,
           navigationActions = navigationActions,
           pictureTaker = pictureTaker,
       )
@@ -394,6 +403,7 @@ class DeckMenuTest {
           flashcardViewModel = flashcardViewModel,
           userViewModel = userViewModel,
           fileViewModel = fileViewModel,
+          folderViewModel = folderViewModel,
           navigationActions = navigationActions,
           pictureTaker = pictureTaker,
       )
@@ -430,6 +440,7 @@ class DeckMenuTest {
           flashcardViewModel = flashcardViewModel,
           userViewModel = userViewModel,
           fileViewModel = fileViewModel,
+          folderViewModel = folderViewModel,
           navigationActions = navigationActions,
           pictureTaker = pictureTaker,
       )
@@ -459,6 +470,7 @@ class DeckMenuTest {
           flashcardViewModel = flashcardViewModel,
           userViewModel = userViewModel,
           fileViewModel = fileViewModel,
+          folderViewModel = folderViewModel,
           navigationActions = navigationActions,
           pictureTaker = pictureTaker,
       )
@@ -546,6 +558,7 @@ class DeckMenuTest {
           flashcardViewModel = flashcardViewModel,
           userViewModel = userViewModel,
           fileViewModel = fileViewModel,
+          folderViewModel = folderViewModel,
           navigationActions = navigationActions,
           pictureTaker = pictureTaker,
       )

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/FolderContentTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/FolderContentTest.kt
@@ -112,7 +112,7 @@ class FolderContentTest {
     userViewModel.addUser(testUser, {}, {})
 
     noteViewModel.getRootNotesFromUid("1")
-    folderViewModel.getRootFoldersFromUserId("1")
+    folderViewModel.getRootFoldersFromUserId("1", isDeckView = false)
 
     folderViewModel.selectedFolder(selectedFolder)
     composeTestRule.setContent {

--- a/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/NoteOverviewTest.kt
+++ b/app/src/androidTest/java/com/github/onlynotesswent/ui/overview/NoteOverviewTest.kt
@@ -125,7 +125,7 @@ class NoteOverviewTest {
       onSuccess(folderList)
     }
     noteViewModel.getRootNotesFromUid("1")
-    folderViewModel.getRootFoldersFromUserId("1")
+    folderViewModel.getRootFoldersFromUserId("1", isDeckView = false)
     composeTestRule.onNodeWithTag("noteAndFolderList").assertIsDisplayed()
   }
 
@@ -168,7 +168,7 @@ class NoteOverviewTest {
       val onSuccess = invocation.getArgument<(List<Folder>) -> Unit>(1)
       onSuccess(folderList)
     }
-    folderViewModel.getRootFoldersFromUserId("1")
+    folderViewModel.getRootFoldersFromUserId("1", isDeckView = false)
     composeTestRule.onAllNodesWithTag("folderCard").onFirst().assertIsDisplayed()
     composeTestRule.onAllNodesWithTag("folderCard").onFirst().performClick()
     val folderContentsScreen =
@@ -257,7 +257,7 @@ class NoteOverviewTest {
       onSuccess(folderList)
     }
     noteViewModel.getRootNotesFromUid("1")
-    folderViewModel.getRootFoldersFromUserId("1")
+    folderViewModel.getRootFoldersFromUserId("1", isDeckView = false)
     composeTestRule.onNodeWithTag("noteAndFolderList").assertIsDisplayed()
 
     composeTestRule.onNodeWithTag("noteCard").assertIsDisplayed()
@@ -287,7 +287,7 @@ class NoteOverviewTest {
       onSuccess(folderList)
     }
     noteViewModel.getRootNotesFromUid("1")
-    folderViewModel.getRootFoldersFromUserId("1")
+    folderViewModel.getRootFoldersFromUserId("1", isDeckView = false)
     composeTestRule.onNodeWithTag("noteModalBottomSheet").assertIsNotDisplayed()
     composeTestRule.onNodeWithTag("showBottomSheetButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("showBottomSheetButton").performClick()

--- a/app/src/main/java/com/github/onlynotesswent/MainActivity.kt
+++ b/app/src/main/java/com/github/onlynotesswent/MainActivity.kt
@@ -179,31 +179,31 @@ fun OnlyNotesApp(scanner: Scanner, pictureTaker: PictureTaker, textExtractor: Te
 
         DeckOverviewScreen(navigationActions, deckViewModel, userViewModel, folderViewModel)
       }
-        composable(Screen.DECK_MENU) { navBackStackEntry ->
-            val deckId = navBackStackEntry.arguments?.getString("deckId")
-            deckId?.let { deckViewModel.getDeckById(it) }
-            DeckScreen(
-                userViewModel,
-                deckViewModel,
-                flashcardViewModel,
-                fileViewModel,
-                folderViewModel,
-                pictureTaker,
-                navigationActions)
-        }
-        composable(Screen.DECK_PLAY) { navBackStackEntry ->
-            val deckId = navBackStackEntry.arguments?.getString("deckId")
-            val mode = navBackStackEntry.arguments?.getString("mode")
+      composable(Screen.DECK_MENU) { navBackStackEntry ->
+        val deckId = navBackStackEntry.arguments?.getString("deckId")
+        deckId?.let { deckViewModel.getDeckById(it) }
+        DeckScreen(
+            userViewModel,
+            deckViewModel,
+            flashcardViewModel,
+            fileViewModel,
+            folderViewModel,
+            pictureTaker,
+            navigationActions)
+      }
+      composable(Screen.DECK_PLAY) { navBackStackEntry ->
+        val deckId = navBackStackEntry.arguments?.getString("deckId")
+        val mode = navBackStackEntry.arguments?.getString("mode")
 
-            // Refresh deck if it is not null
-            LaunchedEffect(deckId) {
-                if (deckId != null && deckId != "{deckId}")
-                    deckViewModel.getDeckById(
-                        deckId, { deckViewModel.playDeckWithMode(it, Deck.PlayMode.fromString(mode)) })
-            }
-            DeckPlayScreen(
-                navigationActions, userViewModel, deckViewModel, flashcardViewModel, fileViewModel)
+        // Refresh deck if it is not null
+        LaunchedEffect(deckId) {
+          if (deckId != null && deckId != "{deckId}")
+              deckViewModel.getDeckById(
+                  deckId, { deckViewModel.playDeckWithMode(it, Deck.PlayMode.fromString(mode)) })
         }
+        DeckPlayScreen(
+            navigationActions, userViewModel, deckViewModel, flashcardViewModel, fileViewModel)
+      }
       composable(
           route = Screen.FOLDER_CONTENTS,
           enterTransition = { scaleIn(animationSpec = tween(300, easing = EaseIn)) },

--- a/app/src/main/java/com/github/onlynotesswent/MainActivity.kt
+++ b/app/src/main/java/com/github/onlynotesswent/MainActivity.kt
@@ -179,19 +179,31 @@ fun OnlyNotesApp(scanner: Scanner, pictureTaker: PictureTaker, textExtractor: Te
 
         DeckOverviewScreen(navigationActions, deckViewModel, userViewModel, folderViewModel)
       }
-      composable(Screen.DECK_MENU) {
-        DeckScreen(
-            userViewModel,
-            deckViewModel,
-            flashcardViewModel,
-            fileViewModel,
-            pictureTaker,
-            navigationActions)
-      }
-      composable(Screen.DECK_PLAY) {
-        DeckPlayScreen(
-            navigationActions, userViewModel, deckViewModel, flashcardViewModel, fileViewModel)
-      }
+        composable(Screen.DECK_MENU) { navBackStackEntry ->
+            val deckId = navBackStackEntry.arguments?.getString("deckId")
+            deckId?.let { deckViewModel.getDeckById(it) }
+            DeckScreen(
+                userViewModel,
+                deckViewModel,
+                flashcardViewModel,
+                fileViewModel,
+                folderViewModel,
+                pictureTaker,
+                navigationActions)
+        }
+        composable(Screen.DECK_PLAY) { navBackStackEntry ->
+            val deckId = navBackStackEntry.arguments?.getString("deckId")
+            val mode = navBackStackEntry.arguments?.getString("mode")
+
+            // Refresh deck if it is not null
+            LaunchedEffect(deckId) {
+                if (deckId != null && deckId != "{deckId}")
+                    deckViewModel.getDeckById(
+                        deckId, { deckViewModel.playDeckWithMode(it, Deck.PlayMode.fromString(mode)) })
+            }
+            DeckPlayScreen(
+                navigationActions, userViewModel, deckViewModel, flashcardViewModel, fileViewModel)
+        }
       composable(
           route = Screen.FOLDER_CONTENTS,
           enterTransition = { scaleIn(animationSpec = tween(300, easing = EaseIn)) },
@@ -236,30 +248,6 @@ fun OnlyNotesApp(scanner: Scanner, pictureTaker: PictureTaker, textExtractor: Te
             folderViewModel,
             deckViewModel,
             fileViewModel)
-      }
-      composable(Screen.DECK_MENU) { navBackStackEntry ->
-        val deckId = navBackStackEntry.arguments?.getString("deckId")
-        deckId?.let { deckViewModel.getDeckById(it) }
-        DeckScreen(
-            userViewModel,
-            deckViewModel,
-            flashcardViewModel,
-            fileViewModel,
-            pictureTaker,
-            navigationActions)
-      }
-      composable(Screen.DECK_PLAY) { navBackStackEntry ->
-        val deckId = navBackStackEntry.arguments?.getString("deckId")
-        val mode = navBackStackEntry.arguments?.getString("mode")
-
-        // Refresh deck if it is not null
-        LaunchedEffect(deckId) {
-          if (deckId != null && deckId != "{deckId}")
-              deckViewModel.getDeckById(
-                  deckId, { deckViewModel.playDeckWithMode(it, Deck.PlayMode.fromString(mode)) })
-        }
-        DeckPlayScreen(
-            navigationActions, userViewModel, deckViewModel, flashcardViewModel, fileViewModel)
       }
     }
 

--- a/app/src/main/java/com/github/onlynotesswent/model/folder/FolderViewModel.kt
+++ b/app/src/main/java/com/github/onlynotesswent/model/folder/FolderViewModel.kt
@@ -109,7 +109,7 @@ class FolderViewModel(private val repository: FolderRepository) : ViewModel() {
       folder: Folder,
       onSuccess: () -> Unit = {},
       onFailure: (Exception) -> Unit = {},
-      isDeckView: Boolean = false,
+      isDeckView: Boolean,
       useCache: Boolean = false
   ) {
     viewModelScope.launch {
@@ -141,7 +141,7 @@ class FolderViewModel(private val repository: FolderRepository) : ViewModel() {
       onSuccess: () -> Unit = {},
       onFailure: (Exception) -> Unit = {},
       useCache: Boolean = false,
-      isDeckView: Boolean = false
+      isDeckView: Boolean
   ) {
     viewModelScope.launch {
       repository.deleteFolderById(
@@ -170,13 +170,13 @@ class FolderViewModel(private val repository: FolderRepository) : ViewModel() {
       onSuccess: () -> Unit = {},
       onFailure: (Exception) -> Unit = {},
       useCache: Boolean = false,
-      isDeckView: Boolean = false
+      isDeckView: Boolean? = null
   ) {
     viewModelScope.launch {
       repository.deleteFoldersFromUid(
           userId = userId,
           onSuccess = {
-            getRootFoldersFromUserId(userId, isDeckView)
+            isDeckView?.let { getRootFoldersFromUserId(userId, it) }
             onSuccess()
           },
           onFailure = onFailure,
@@ -223,7 +223,7 @@ class FolderViewModel(private val repository: FolderRepository) : ViewModel() {
    */
   fun getRootFoldersFromUserId(
       userId: String,
-      isDeckView: Boolean = false,
+      isDeckView: Boolean,
       onSuccess: (List<Folder>) -> Unit = {},
       onFailure: (Exception) -> Unit = {},
       useCache: Boolean = false
@@ -384,7 +384,7 @@ class FolderViewModel(private val repository: FolderRepository) : ViewModel() {
       onSuccess: () -> Unit = {},
       onFailure: (Exception) -> Unit = {},
       useCache: Boolean = false,
-      isDeckView: Boolean = false
+      isDeckView: Boolean
   ) {
     viewModelScope.launch {
       repository.updateFolder(
@@ -598,7 +598,8 @@ class FolderViewModel(private val repository: FolderRepository) : ViewModel() {
       } else {
         updateFolder(
             selectedFolder.value!!.copy(
-                parentFolderId = chosenFolder?.id, lastModified = Timestamp.now()))
+                parentFolderId = chosenFolder?.id, lastModified = Timestamp.now()),
+            isDeckView = selectedFolder.value!!.isDeckFolder)
         clearSelectedFolder()
         onSuccess()
       }

--- a/app/src/main/java/com/github/onlynotesswent/ui/deck/DeckMenu.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/deck/DeckMenu.kt
@@ -152,9 +152,7 @@ fun DeckScreen(
               onSaveClick = {
                 Toast.makeText(context, "Not Implemented", Toast.LENGTH_LONG).show()
               },
-              onSaveCopyClick = {
-                saveCopyDialogExpanded.value = true
-              })
+              onSaveCopyClick = { saveCopyDialogExpanded.value = true })
         }
       }) { innerPadding ->
         if (selectedDeck.value == null) {
@@ -204,9 +202,8 @@ fun DeckScreen(
                 } else if (editDialogExpanded.value) {
                   EditDeckDialog(deckViewModel, userViewModel, { editDialogExpanded.value = false })
                 } else if (saveCopyDialogExpanded.value) {
-                    FileSystemPopup({ saveCopyDialogExpanded.value = false }, folderViewModel, {} )
+                  FileSystemPopup({ saveCopyDialogExpanded.value = false }, folderViewModel, {})
                 }
-
 
                 // Play modes bottom sheet:
                 if (playModesShown.value)

--- a/app/src/main/java/com/github/onlynotesswent/ui/deck/DeckMenu.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/deck/DeckMenu.kt
@@ -62,11 +62,13 @@ import com.github.onlynotesswent.model.deck.Deck.SortMode
 import com.github.onlynotesswent.model.deck.DeckViewModel
 import com.github.onlynotesswent.model.file.FileViewModel
 import com.github.onlynotesswent.model.flashcard.FlashcardViewModel
+import com.github.onlynotesswent.model.folder.FolderViewModel
 import com.github.onlynotesswent.model.user.User
 import com.github.onlynotesswent.model.user.UserViewModel
 import com.github.onlynotesswent.ui.common.CustomDropDownMenu
 import com.github.onlynotesswent.ui.common.CustomDropDownMenuItem
 import com.github.onlynotesswent.ui.common.EditDeckDialog
+import com.github.onlynotesswent.ui.common.FileSystemPopup
 import com.github.onlynotesswent.ui.common.FlashcardDialog
 import com.github.onlynotesswent.ui.common.FlashcardViewItem
 import com.github.onlynotesswent.ui.common.LoadingIndicator
@@ -94,6 +96,7 @@ fun DeckScreen(
     deckViewModel: DeckViewModel,
     flashcardViewModel: FlashcardViewModel,
     fileViewModel: FileViewModel,
+    folderViewModel: FolderViewModel,
     pictureTaker: PictureTaker,
     navigationActions: NavigationActions
 ) {
@@ -110,7 +113,7 @@ fun DeckScreen(
   val editDialogExpanded = remember { mutableStateOf(false) }
 
   val publicFabDropdownMenuShown = remember { mutableStateOf(false) }
-  // TODO: add mutable states for save to favourites and create local copy dialogs
+  val saveCopyDialogExpanded = remember { mutableStateOf(false) }
 
   val sortOptionsShown = remember { mutableStateOf(false) }
   val sortMode = remember { mutableStateOf(SortMode.ALPHABETICAL) }
@@ -150,7 +153,7 @@ fun DeckScreen(
                 Toast.makeText(context, "Not Implemented", Toast.LENGTH_LONG).show()
               },
               onSaveCopyClick = {
-                Toast.makeText(context, "Not Implemented", Toast.LENGTH_LONG).show()
+                saveCopyDialogExpanded.value = true
               })
         }
       }) { innerPadding ->
@@ -200,7 +203,10 @@ fun DeckScreen(
                   }
                 } else if (editDialogExpanded.value) {
                   EditDeckDialog(deckViewModel, userViewModel, { editDialogExpanded.value = false })
+                } else if (saveCopyDialogExpanded.value) {
+                    FileSystemPopup({ saveCopyDialogExpanded.value = false }, folderViewModel, {} )
                 }
+
 
                 // Play modes bottom sheet:
                 if (playModesShown.value)

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/FolderContent.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/FolderContent.kt
@@ -394,7 +394,7 @@ fun FolderContentTopBar(
               title = stringResource(R.string.delete_folder),
               text = stringResource(R.string.confirm_delete_folder),
               onConfirm = {
-                folderViewModel.deleteFolderById(folder.id, folder.userId)
+                folderViewModel.deleteFolderById(folder.id, folder.userId, isDeckView = isDeckView)
                 folderViewModel.clearSelectedFolder()
 
                 folderViewModel.getRootDeckFoldersFromUserId(currentUser.value!!.uid)
@@ -494,7 +494,8 @@ fun handleSubFoldersAndContent(
   // If folder is subfolder, set parent Id and folder Id of sub
   // elements to parent folder id
   userFolderSubFolders.forEach { subFolder ->
-    folderViewModel.updateFolder(subFolder.copy(parentFolderId = folder.parentFolderId))
+    folderViewModel.updateFolder(
+        subFolder.copy(parentFolderId = folder.parentFolderId), isDeckView = isDeckView)
   }
   if (isDeckView) {
     userFolderDecks!!.forEach { deck ->

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/FolderContent.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/FolderContent.kt
@@ -167,7 +167,8 @@ fun FolderContentScreen(
                 onConfirm = { name, vis ->
                   folderViewModel.updateFolder(
                       folder.value!!.copy(
-                          name = name, visibility = vis, lastModified = Timestamp.now()))
+                          name = name, visibility = vis, lastModified = Timestamp.now()),
+                      isDeckView = isDeckView)
                   updatedName = name
                   showUpdateDialog = false
                 },

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/FolderContent.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/FolderContent.kt
@@ -221,7 +221,8 @@ fun FolderContentScreen(
                           parentFolderId = folder.value!!.id,
                           visibility = visibility,
                           lastModified = Timestamp.now(),
-                          isDeckFolder = isDeckView))
+                          isDeckFolder = isDeckView),
+                      isDeckView = isDeckView)
                   navigationActions.navigateTo(
                       Screen.FOLDER_CONTENTS.replace(
                           oldValue = "{folderId}", newValue = newFolderId))

--- a/app/src/main/java/com/github/onlynotesswent/ui/overview/NoteOverview.kt
+++ b/app/src/main/java/com/github/onlynotesswent/ui/overview/NoteOverview.kt
@@ -127,7 +127,8 @@ fun NoteOverviewScreen(
                         userId = userViewModel.currentUser.value!!.uid,
                         parentFolderId = parentFolderId.value,
                         visibility = visibility,
-                        lastModified = Timestamp.now()))
+                        lastModified = Timestamp.now()),
+                    isDeckView = false)
 
                 showCreateFolderDialog = false
                 navigationActions.navigateTo(

--- a/app/src/main/java/com/github/onlynotesswent/utils/NotesToFlashcard.kt
+++ b/app/src/main/java/com/github/onlynotesswent/utils/NotesToFlashcard.kt
@@ -355,7 +355,8 @@ class NotesToFlashcard(
           folderViewModel.addFolder(
               newDeckFolder,
               onSuccess = { continuation.resume(newDeckFolder) },
-              onFailure = { continuation.resumeWithException(it) })
+              onFailure = { continuation.resumeWithException(it) },
+              isDeckView = false)
         },
         onSuccess = { existingFolders ->
           if (parentDeckFolder == null) {
@@ -378,7 +379,8 @@ class NotesToFlashcard(
               folderViewModel.addFolder(
                   newDeckFolder,
                   onSuccess = { continuation.resume(newDeckFolder) },
-                  onFailure = { continuation.resumeWithException(it) })
+                  onFailure = { continuation.resumeWithException(it) },
+                  isDeckView = false)
             }
           }
         },

--- a/app/src/test/java/com/github/onlynotesswent/model/folder/FolderViewModelTest.kt
+++ b/app/src/test/java/com/github/onlynotesswent/model/folder/FolderViewModelTest.kt
@@ -161,7 +161,7 @@ class FolderViewModelTest {
     }
 
     var onSuccessCalled = false
-    folderViewModel.addFolder(testFolder, { onSuccessCalled = true })
+    folderViewModel.addFolder(testFolder, { onSuccessCalled = true }, isDeckView = false)
     assert(onSuccessCalled)
   }
 
@@ -173,7 +173,7 @@ class FolderViewModelTest {
     }
 
     var onSuccessCalled = false
-    folderViewModel.updateFolder(testFolder, { onSuccessCalled = true })
+    folderViewModel.updateFolder(testFolder, { onSuccessCalled = true }, isDeckView = false)
     assert(onSuccessCalled)
   }
 
@@ -185,7 +185,8 @@ class FolderViewModelTest {
     }
 
     var onSuccessCalled = false
-    folderViewModel.deleteFolderById(testFolder.id, testFolder.userId, { onSuccessCalled = true })
+    folderViewModel.deleteFolderById(
+        testFolder.id, testFolder.userId, { onSuccessCalled = true }, isDeckView = false)
     assert(onSuccessCalled)
   }
 
@@ -235,7 +236,7 @@ class FolderViewModelTest {
       val onSuccess = invocation.getArgument<() -> Unit>(1)
       onSuccess()
     }
-    folderViewModel.updateFolder(testFolder)
+    folderViewModel.updateFolder(testFolder, isDeckView = false)
 
     verify(mockFolderRepository).updateFolder(eq(testFolder), any(), any(), any())
     verify(mockFolderRepository).getRootNoteFoldersFromUserId(eq("1"), any(), any(), any())


### PR DESCRIPTION
# Description

This PR allows the user to choose where to save a copy of a public deck. It uses the filesystem popup from the save local copy option of the save FAB.

Fixes #248 

# How Has This Been Tested?

No tests. The popup and the deck menu screen are well tested. So for the save deck feature, the only untested code is the few lines of the callback which can't fail due to their sheer simplicity. The other lines of codes of this PR are bug fixes which do no need more tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged in downstream modules, no conflicts with main
